### PR TITLE
resolve dns via http json handler

### DIFF
--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -47,10 +47,16 @@ properties:
     description: "allow the Windows dns caching service to remain in operation on this VM"
     default: false
 
-  http_json_endpoints:
-    description: "Hash of domain key to endpoints"
+  handlers:
+    description: "Array of handler configurations"
+    default: []
     example:
-      internal.domain.: http://endpoint
+      - domain: local.internal.
+        cache:
+          enabled: true
+        source:
+          type: http
+          url: http://some.endpoint.local
 
   recursors:
     description: "Addresses of upstream DNS servers used for recursively resolving queries"

--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -47,6 +47,11 @@ properties:
     description: "allow the Windows dns caching service to remain in operation on this VM"
     default: false
 
+  http_json_endpoints:
+    description: "Hash of domain key to endpoints"
+    example:
+      internal.domain.: http://endpoint
+
   recursors:
     description: "Addresses of upstream DNS servers used for recursively resolving queries"
     default: []

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -18,6 +18,7 @@
   },
   cache: {
     enabled: p('cache.enabled')
-  }
+  },
+  http_json_endpoints: p('http_json_endpoints')
 }.to_json
 %>

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -19,6 +19,6 @@
   cache: {
     enabled: p('cache.enabled')
   },
-  http_json_endpoints: p('http_json_endpoints')
+  handlers: p('handlers')
 }.to_json
 %>

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -49,9 +49,10 @@ properties:
   override_nameserver:
     description: "Configure ourselves as the system nameserver (e.g. /etc/resolv.conf will be watched and overwritten)"
     default: true
-  
+
   http_json_endpoints:
     description: "Hash of domain key to endpoints"
+    default: {}
     example:
       internal.domain.: http://endpoint
 

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -55,12 +55,11 @@ properties:
     default: []
     example:
       - domain: local.internal.
-        caching:
+        cache:
           enabled: true
         source:
           type: http
           url: http://some.endpoint.local
-          tls: ...
 
   recursors:
     description: "Addresses of upstream DNS servers used for recursively resolving queries"

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -49,6 +49,11 @@ properties:
   override_nameserver:
     description: "Configure ourselves as the system nameserver (e.g. /etc/resolv.conf will be watched and overwritten)"
     default: true
+  
+  http_json_endpoints:
+    description: "Hash of domain key to endpoints"
+    example:
+      internal.domain.: http://endpoint
 
   recursors:
     description: "Addresses of upstream DNS servers used for recursively resolving queries"

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -50,11 +50,17 @@ properties:
     description: "Configure ourselves as the system nameserver (e.g. /etc/resolv.conf will be watched and overwritten)"
     default: true
 
-  http_json_endpoints:
-    description: "Hash of domain key to endpoints"
-    default: {}
+  handlers:
+    description: "Array of handler configurations"
+    default: []
     example:
-      internal.domain.: http://endpoint
+      - domain: local.internal.
+        caching:
+          enabled: true
+        source:
+          type: http
+          url: http://some.endpoint.local
+          tls: ...
 
   recursors:
     description: "Addresses of upstream DNS servers used for recursively resolving queries"

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -1,4 +1,14 @@
 <%=
+handlers = p('handlers')
+handlers.each do |handler|
+    if handler["domain"].nil?
+      raise "expected a domain for handler #{handler}"
+    end
+    if handler.fetch("source", {})["type"].nil?
+      raise "expected a type for handler #{handler}"
+    end
+end
+
 {
   address: p('address'),
   port: p('port'),

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -18,6 +18,7 @@
   },
   cache: {
     enabled: p('cache.enabled')
-  }
+  },
+  http_json_endpoints: p('http_json_endpoints')
 }.to_json
 %>

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -19,6 +19,6 @@
   cache: {
     enabled: p('cache.enabled')
   },
-  http_json_endpoints: p('http_json_endpoints')
+  handlers: p('handlers')
 }.to_json
 %>

--- a/src/bosh-dns/acceptance_tests/http_json_test.go
+++ b/src/bosh-dns/acceptance_tests/http_json_test.go
@@ -1,0 +1,75 @@
+package acceptance_test
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	boshlog "github.com/cloudfoundry/bosh-utils/logger"
+	"github.com/cloudfoundry/bosh-utils/system"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/gexec"
+)
+
+var _ = Describe("HTTP JSON Server integration", func() {
+	var (
+		firstInstance  instanceInfo
+		httpDNSSession *gexec.Session
+	)
+
+	Describe("DNS endpoint", func() {
+		BeforeEach(func() {
+			var err error
+			cmd := exec.Command(pathToTestHTTPDNSServer)
+			httpDNSSession, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			ensureHTTPJSONEndpointIsDefinedByDnsRelease("http://172.17.0.1:8081")
+			firstInstance = allDeployedInstances[0]
+		})
+
+		AfterEach(func() {
+			httpDNSSession.Kill()
+		})
+
+		It("answers queries with the response from the http server", func() {
+			cmd := exec.Command("dig", strings.Split(fmt.Sprintf("-t A app-id.internal.local @%s", firstInstance.IP), " ")...)
+			session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+			Expect(err).NotTo(HaveOccurred())
+
+			Eventually(session, 10*time.Second).Should(gexec.Exit(0))
+			output := string(session.Out.Contents())
+			Expect(output).To(ContainSubstring("flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0"))
+			Expect(output).To(MatchRegexp("app-id.internal.local.\\s+0\\s+IN\\s+A\\s+192\\.168\\.0\\.1"))
+			Expect(output).To(ContainSubstring(fmt.Sprintf("SERVER: %s#53", firstInstance.IP)))
+		})
+	})
+})
+
+func ensureHTTPJSONEndpointIsDefinedByDnsRelease(jsonServerAddress string) {
+	cmdRunner = system.NewExecCmdRunner(boshlog.NewLogger(boshlog.LevelDebug))
+
+	manifestPath, err := filepath.Abs(fmt.Sprintf("../test_yml_assets/%s.yml", testManifestName()))
+	Expect(err).ToNot(HaveOccurred())
+	aliasProvidingPath, err := filepath.Abs("dns-acceptance-release")
+	Expect(err).ToNot(HaveOccurred())
+	enableHTTPJSONEndpointsPath, err := filepath.Abs("../test_yml_assets/enable-http-json-endpoints.yml")
+	Expect(err).ToNot(HaveOccurred())
+
+	updateCloudConfigWithDefaultCloudConfig()
+
+	stdOut, stdErr, exitStatus, err := cmdRunner.RunCommand(boshBinaryPath,
+		"-n", "-d", boshDeployment, "deploy",
+		"-o", enableHTTPJSONEndpointsPath,
+		"-v", fmt.Sprintf("name=%s", boshDeployment),
+		"-v", fmt.Sprintf("acceptance_release_path=%s", aliasProvidingPath),
+		"-v", fmt.Sprintf("http_json_server_address=%s", jsonServerAddress),
+		manifestPath,
+	)
+	Expect(err).ToNot(HaveOccurred())
+	Expect(exitStatus).To(Equal(0), fmt.Sprintf("stdOut: %s \n stdErr: %s", stdOut, stdErr))
+	allDeployedInstances = getInstanceInfos(boshBinaryPath)
+}

--- a/src/bosh-dns/acceptance_tests/http_json_test.go
+++ b/src/bosh-dns/acceptance_tests/http_json_test.go
@@ -42,7 +42,7 @@ var _ = Describe("HTTP JSON Server integration", func() {
 
 			Eventually(session, 10*time.Second).Should(gexec.Exit(0))
 			output := string(session.Out.Contents())
-			Expect(output).To(ContainSubstring("flags: qr aa rd; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0"))
+			Expect(output).To(ContainSubstring("flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0"))
 			Expect(output).To(MatchRegexp("app-id.internal.local.\\s+0\\s+IN\\s+A\\s+192\\.168\\.0\\.1"))
 			Expect(output).To(ContainSubstring(fmt.Sprintf("SERVER: %s#53", firstInstance.IP)))
 		})

--- a/src/bosh-dns/acceptance_tests/init_test.go
+++ b/src/bosh-dns/acceptance_tests/init_test.go
@@ -24,6 +24,7 @@ func TestAcceptance(t *testing.T) {
 
 var (
 	pathToTestRecursorServer string
+	pathToTestHTTPDNSServer  string
 	boshBinaryPath           string
 	allDeployedInstances     []instanceInfo
 	boshDeployment           string
@@ -44,6 +45,9 @@ var _ = BeforeSuite(func() {
 
 	var err error
 	pathToTestRecursorServer, err = gexec.Build("bosh-dns/acceptance_tests/test_recursor")
+	Expect(err).NotTo(HaveOccurred())
+
+	pathToTestHTTPDNSServer, err = gexec.Build("bosh-dns/acceptance_tests/test_http_dns_server")
 	Expect(err).NotTo(HaveOccurred())
 })
 

--- a/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
+++ b/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"net"
+	"net/http"
+)
+
+func main() {
+	http.HandleFunc("/", func(responseWriter http.ResponseWriter, req *http.Request) {
+
+		if req.URL.RawQuery != "type=1&name=app-id.internal.local." {
+			panic(fmt.Sprintf("Expected query 'type=1&name=app-id.internal.local.' Actual: '%s'", req.URL.RawQuery))
+		}
+
+		responseJSON := `{
+					"Status": 0,
+					"TC": false,
+					"RD": true,
+					"RA": true,
+					"AD": false,
+					"CD": false,
+					"Question":
+					[
+						{
+							"name": "app-id.internal.local.",
+							"type": 1
+						}
+					],
+					"Answer":
+					[
+						{
+							"name": "app-id.internal.local.",
+							"type": 1,
+							"TTL":  0,
+							"data": "192.168.0.1"
+						}
+					],
+					"Additional": [ ],
+					"edns_client_subnet": "12.34.56.78/0"
+				}`
+
+		responseWriter.Write([]byte(responseJSON))
+	})
+
+	listener, err := net.Listen("tcp", "172.17.0.1:8081")
+	if err != nil {
+		panic(err)
+	}
+
+	err = http.Serve(listener, nil)
+	if err != nil {
+		panic(err)
+	}
+}

--- a/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
+++ b/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
@@ -43,7 +43,7 @@ func main() {
 		responseWriter.Write([]byte(responseJSON))
 	})
 
-	listener, err := net.Listen("tcp", "172.17.0.1:8081")
+	listener, err := net.Listen("tcp", "0.0.0.0:8081")
 	if err != nil {
 		panic(err)
 	}

--- a/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
+++ b/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
@@ -9,11 +9,14 @@ import (
 func main() {
 	http.HandleFunc("/", func(responseWriter http.ResponseWriter, req *http.Request) {
 
-		if req.URL.RawQuery != "type=1&name=app-id.internal.local." {
-			panic(fmt.Sprintf("Expected query 'type=1&name=app-id.internal.local.' Actual: '%s'", req.URL.RawQuery))
+		if req.URL.RawQuery != "type=1&name=app-id.internal.local." &&
+			req.URL.RawQuery != "type=1&name=large-id.internal.local." {
+			panic(fmt.Sprintf("Unexpected query '%s'", req.URL.RawQuery))
 		}
 
-		responseJSON := `{
+		var responseJSON string
+		if req.URL.RawQuery == "type=1&name=app-id.internal.local." {
+			responseJSON = `{
 					"Status": 0,
 					"TC": false,
 					"RD": true,
@@ -39,6 +42,106 @@ func main() {
 					"Additional": [ ],
 					"edns_client_subnet": "12.34.56.78/0"
 				}`
+		} else {
+			responseJSON = `{
+					"Status": 0,
+					"TC": false,
+					"RD": true,
+					"RA": true,
+					"AD": false,
+					"CD": false,
+					"Question":
+					[
+						{
+							"name": "large-id.internal.local.",
+							"type": 1
+						}
+					],
+					"Answer":
+					[
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 1526,
+							"data": "192.168.0.1"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 1526,
+							"data": "192.168.0.2"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 1526,
+							"data": "192.168.0.3"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.4"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.5"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.6"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.7"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.8"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.9"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.10"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.11"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.12"
+						},
+						{
+							"name": "large-id.internal-domain.",
+							"type": 1,
+							"TTL": 224,
+							"data": "192.168.0.13"
+						}
+					],
+					"Additional": [ ],
+					"edns_client_subnet": "12.34.56.78/0"
+				}`
+		}
 
 		responseWriter.Write([]byte(responseJSON))
 	})

--- a/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
+++ b/src/bosh-dns/acceptance_tests/test_http_dns_server/main.go
@@ -4,18 +4,19 @@ import (
 	"fmt"
 	"net"
 	"net/http"
+	"net/url"
 )
 
 func main() {
 	http.HandleFunc("/", func(responseWriter http.ResponseWriter, req *http.Request) {
+		var responseJSON string
+		queryValues, err := url.ParseQuery(req.URL.RawQuery)
 
-		if req.URL.RawQuery != "type=1&name=app-id.internal.local." &&
-			req.URL.RawQuery != "type=1&name=large-id.internal.local." {
+		if err != nil {
 			panic(fmt.Sprintf("Unexpected query '%s'", req.URL.RawQuery))
 		}
 
-		var responseJSON string
-		if req.URL.RawQuery == "type=1&name=app-id.internal.local." {
+		if queryValues.Get("type") == "1" && queryValues.Get("name") == "app-id.internal.local." {
 			responseJSON = `{
 					"Status": 0,
 					"TC": false,
@@ -42,7 +43,7 @@ func main() {
 					"Additional": [ ],
 					"edns_client_subnet": "12.34.56.78/0"
 				}`
-		} else {
+		} else if queryValues.Get("type") == "1" && queryValues.Get("name") == "large-id.internal.local."{
 			responseJSON = `{
 					"Status": 0,
 					"TC": false,
@@ -141,6 +142,8 @@ func main() {
 					"Additional": [ ],
 					"edns_client_subnet": "12.34.56.78/0"
 				}`
+		} else {
+			panic(fmt.Sprintf("Unexpected query '%s'", req.URL.RawQuery))
 		}
 
 		responseWriter.Write([]byte(responseJSON))

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -28,6 +28,7 @@ type Config struct {
 type Handler struct {
 	Domain string `json:"domain"`
 	Source Source `json:"source"`
+	Cache  Cache  `json:"cache"`
 }
 
 type Source struct {

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -22,6 +22,8 @@ type Config struct {
 
 	Health HealthConfig `json:"health"`
 	Cache  Cache        `json:"cache"`
+
+	HTTPJSONEndpoints map[string]string `json:"http_json_endpoints"`
 }
 
 type HealthConfig struct {

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -20,10 +20,19 @@ type Config struct {
 	AliasFilesGlob  string   `json:"alias_files_glob"`
 	UpcheckDomains  []string `json:"upcheck_domains"`
 
-	Health HealthConfig `json:"health"`
-	Cache  Cache        `json:"cache"`
+	Health   HealthConfig `json:"health"`
+	Cache    Cache        `json:"cache"`
+	Handlers []Handler    `json:"handlers"`
+}
 
-	HTTPJSONEndpoints map[string]string `json:"http_json_endpoints"`
+type Handler struct {
+	Domain string `json:"domain"`
+	Source Source `json:"source"`
+}
+
+type Source struct {
+	Type string `json:"type"`
+	URL  string `json:"url,omitempty"`
 }
 
 type HealthConfig struct {

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Config", func() {
 		upcheckDomains = []string{"upcheck.domain.", "health2.bosh."}
 	})
 
-	FIt("returns config from a config file", func() {
+	It("returns config from a config file", func() {
 		configContents, err := json.Marshal(map[string]interface{}{
 			"address":          listenAddress,
 			"port":             listenPort,

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -66,9 +66,13 @@ var _ = Describe("Config", func() {
 			"cache": map[string]interface{}{
 				"enabled": true,
 			},
-			"http_json_endpoints": map[string]string{
-				"http.tld.": "http.server.address",
-			},
+			"handlers": []map[string]interface{}{{
+				"domain": "some.tld.",
+				"source": map[string]interface{}{
+					"type": "http",
+					"url":  "http.server.address",
+				},
+			}},
 		})
 		configFilePath := writeConfigFile(string(configContents))
 
@@ -101,8 +105,14 @@ var _ = Describe("Config", func() {
 			Cache: config.Cache{
 				Enabled: true,
 			},
-			HTTPJSONEndpoints: map[string]string{
-				"http.tld.": "http.server.address",
+			Handlers: []config.Handler{
+				{
+					Domain: "some.tld.",
+					Source: config.Source{
+						Type: "http",
+						URL:  "http.server.address",
+					},
+				},
 			},
 		}))
 	})

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -66,6 +66,9 @@ var _ = Describe("Config", func() {
 			"cache": map[string]interface{}{
 				"enabled": true,
 			},
+			"http_json_endpoints": map[string]string{
+				"http.tld.": "http.server.address",
+			},
 		})
 		configFilePath := writeConfigFile(string(configContents))
 
@@ -97,6 +100,9 @@ var _ = Describe("Config", func() {
 			},
 			Cache: config.Cache{
 				Enabled: true,
+			},
+			HTTPJSONEndpoints: map[string]string{
+				"http.tld.": "http.server.address",
 			},
 		}))
 	})

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Config", func() {
 		upcheckDomains = []string{"upcheck.domain.", "health2.bosh."}
 	})
 
-	It("returns config from a config file", func() {
+	FIt("returns config from a config file", func() {
 		configContents, err := json.Marshal(map[string]interface{}{
 			"address":          listenAddress,
 			"port":             listenPort,
@@ -68,6 +68,9 @@ var _ = Describe("Config", func() {
 			},
 			"handlers": []map[string]interface{}{{
 				"domain": "some.tld.",
+				"cache": map[string]interface{}{
+					"enabled": true,
+				},
 				"source": map[string]interface{}{
 					"type": "http",
 					"url":  "http.server.address",
@@ -108,6 +111,9 @@ var _ = Describe("Config", func() {
 			Handlers: []config.Handler{
 				{
 					Domain: "some.tld.",
+					Cache: config.Cache{
+						Enabled: true,
+					},
 					Source: config.Source{
 						Type: "http",
 						URL:  "http.server.address",

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -115,7 +115,12 @@ func mainExitCode() int {
 
 	for _, handler := range config.Handlers {
 		if handler.Source.Type == "http" {
-			handlers.AddHandler(mux, clock, handler.Domain, handlers.NewHTTPJSONHandler(handler.Source.URL, logger), logger)
+			var dnsHandler dns.Handler
+			dnsHandler = handlers.NewHTTPJSONHandler(handler.Source.URL, logger)
+			if handler.Cache.Enabled {
+				dnsHandler =  handlers.NewCachingDNSHandler(dnsHandler)
+			}
+			handlers.AddHandler(mux, clock, handler.Domain, dnsHandler, logger)
 		}
 	}
 

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -112,6 +112,9 @@ func mainExitCode() int {
 	handlerRegistrar := handlers.NewHandlerRegistrar(logger, clock, recordsRepo, mux, discoveryHandler)
 
 	handlers.AddHandler(mux, clock, "arpa.", handlers.NewArpaHandler(logger), logger)
+	for domain, endpoint := range config.HTTPJSONEndpoints {
+		handlers.AddHandler(mux, clock, domain, handlers.NewHTTPJSONHandler(endpoint, logger), logger)
+	}
 
 	upchecks := []server.Upcheck{}
 	for _, upcheckDomain := range config.UpcheckDomains {

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -112,6 +112,7 @@ func mainExitCode() int {
 	handlerRegistrar := handlers.NewHandlerRegistrar(logger, clock, recordsRepo, mux, discoveryHandler)
 
 	handlers.AddHandler(mux, clock, "arpa.", handlers.NewArpaHandler(logger), logger)
+
 	for _, handler := range config.Handlers {
 		if handler.Source.Type == "http" {
 			handlers.AddHandler(mux, clock, handler.Domain, handlers.NewHTTPJSONHandler(handler.Source.URL, logger), logger)

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -112,8 +112,10 @@ func mainExitCode() int {
 	handlerRegistrar := handlers.NewHandlerRegistrar(logger, clock, recordsRepo, mux, discoveryHandler)
 
 	handlers.AddHandler(mux, clock, "arpa.", handlers.NewArpaHandler(logger), logger)
-	for domain, endpoint := range config.HTTPJSONEndpoints {
-		handlers.AddHandler(mux, clock, domain, handlers.NewHTTPJSONHandler(endpoint, logger), logger)
+	for _, handler := range config.Handlers {
+		if handler.Source.Type == "http" {
+			handlers.AddHandler(mux, clock, handler.Domain, handlers.NewHTTPJSONHandler(handler.Source.URL, logger), logger)
+		}
 	}
 
 	upchecks := []server.Upcheck{}

--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -559,7 +559,7 @@ var _ = Describe("main", func() {
 			})
 
 			Context("http json domains", func() {
-				It("does something", func() {
+				It("serves the addresses from the http server", func() {
 					c := &dns.Client{Net: "tcp"}
 
 					m := &dns.Msg{}

--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -149,8 +149,33 @@ var _ = Describe("main", func() {
 
 			httpJSONServer = ghttp.NewUnstartedServer()
 			httpJSONServer.AppendHandlers(ghttp.CombineHandlers(
-				ghttp.VerifyRequest("GET", "/ips/app-id.internal-domain."),
-				ghttp.RespondWith(http.StatusOK, `{"ips":["192.168.0.1", "192.168.0.4"]}`),
+				ghttp.VerifyRequest("GET", "/", "name=app-id.internal-domain.&type=255"),
+				ghttp.RespondWith(http.StatusOK, `{
+  "Status": 0,
+  "TC": false,
+  "RD": true,
+  "RA": true,
+  "AD": false,
+  "CD": false,
+  "Question":
+  [
+    {
+      "name": "app-id.internal-domain.",
+      "type": 28
+    }
+  ],
+  "Answer":
+  [
+    {
+      "name": "app-id.internal-domain.",
+      "type": 1,
+      "TTL": 1526,
+      "data": "192.168.0.1"
+    }
+  ],
+  "Additional": [ ],
+  "edns_client_subnet": "12.34.56.78/0"
+}`),
 			),
 			)
 			httpJSONServer.HTTPTestServer.Start()
@@ -535,9 +560,7 @@ var _ = Describe("main", func() {
 
 			Context("http json domains", func() {
 				It("does something", func() {
-					c := &dns.Client{
-						Net: "udp",
-					}
+					c := &dns.Client{Net: "tcp"}
 
 					m := &dns.Msg{}
 
@@ -546,13 +569,10 @@ var _ = Describe("main", func() {
 
 					Expect(err).NotTo(HaveOccurred())
 					Expect(r.Rcode).To(Equal(dns.RcodeSuccess))
-					Expect(r.Answer).To(HaveLen(2))
+					Expect(r.Answer).To(HaveLen(1))
 
 					answer0 := r.Answer[0].(*dns.A)
 					Expect(answer0.A.String()).To(Equal("192.168.0.1"))
-
-					answer1 := r.Answer[1].(*dns.A)
-					Expect(answer1.A.String()).To(Equal("192.168.0.4"))
 				})
 			})
 		})

--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -193,9 +193,13 @@ var _ = Describe("main", func() {
 					"private_key_file": "../healthcheck/assets/test_certs/test_client.key",
 					"check_interval":   checkInterval,
 				},
-				"http_json_endpoints": map[string]string{
-					"internal-domain.": httpJSONServer.URL(),
-				},
+				"handlers": []map[string]interface{}{{
+					"domain": "internal-domain.",
+					"source": map[string]interface{}{
+						"type": "http",
+						"url":  httpJSONServer.URL(),
+					},
+				}},
 			})
 			Expect(err).NotTo(HaveOccurred())
 			cmd = newCommandWithConfig(string(configContents))

--- a/src/bosh-dns/dns/server/handlers/http_json_handler.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler.go
@@ -68,10 +68,14 @@ func (h HTTPJSONHandler) buildResponse(request *dns.Msg) *dns.Msg {
 
 	question := request.Question[0]
 
-	url := fmt.Sprintf("%s/?type=%s&name=%s",
+	queryParams := url.Values{
+		"type": []string{strconv.Itoa(int(question.Qtype))},
+		"name": []string{question.Name},
+	}.Encode()
+
+	url := fmt.Sprintf("%s/?%s",
 		h.address,
-		strconv.Itoa(int(question.Qtype)),
-		url.QueryEscape(question.Name),
+		queryParams,
 	)
 	httpResponse, err := h.client.Get(url)
 

--- a/src/bosh-dns/dns/server/handlers/http_json_handler.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler.go
@@ -76,13 +76,13 @@ func (h HTTPJSONHandler) buildResponse(request *dns.Msg) *dns.Msg {
 	httpResponse, err := h.client.Get(url)
 
 	if err != nil {
-		h.logger.Error(h.logTag, "Error connecting to '%s': %v", h.address, err)
+		h.logger.Error(h.logTag, "error connecting to '%s': %v", h.address, err)
 		responseMsg.SetRcode(request, dns.RcodeServerFailure)
 		return responseMsg
 	}
 
 	if httpResponse.StatusCode != 200 {
-		h.logger.Error(h.logTag, "Non successful response from server '%s': %v", h.address, httpResponse)
+		h.logger.Error(h.logTag, "non successful response from server '%s': %v", h.address, httpResponse)
 		responseMsg.SetRcode(request, dns.RcodeServerFailure)
 		return responseMsg
 	}

--- a/src/bosh-dns/dns/server/handlers/http_json_handler.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler.go
@@ -1,0 +1,81 @@
+package handlers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net"
+
+	"github.com/cloudfoundry/bosh-utils/httpclient"
+	"github.com/cloudfoundry/bosh-utils/logger"
+	"github.com/miekg/dns"
+)
+
+type HTTPJSONHandler struct {
+	address string
+	client  *httpclient.HTTPClient
+	logger  logger.Logger
+	logTag  string
+}
+
+type ipsResponse struct {
+	IPs []string `json:ips`
+}
+
+func NewHTTPJSONHandler(address string, logger logger.Logger) HTTPJSONHandler {
+	return HTTPJSONHandler{
+		address: address,
+		client: httpclient.NewHTTPClient(
+			httpclient.DefaultClient,
+			logger,
+		),
+		logger: logger,
+		logTag: "HTTPJSONHandler",
+	}
+}
+
+func (h HTTPJSONHandler) ServeDNS(responseWriter dns.ResponseWriter, request *dns.Msg) {
+	responseMsg := h.buildResponse(request)
+	if err := responseWriter.WriteMsg(responseMsg); err != nil {
+		h.logger.Error(h.logTag, err.Error())
+	}
+}
+
+func (h HTTPJSONHandler) buildResponse(request *dns.Msg) *dns.Msg {
+	responseMsg := new(dns.Msg)
+	responseMsg.Authoritative = true
+	responseMsg.RecursionAvailable = false
+	responseMsg.SetReply(request)
+	responseMsg.SetRcode(request, dns.RcodeSuccess)
+
+	if len(request.Question) == 0 {
+		return responseMsg
+	}
+	url := fmt.Sprintf("%s/ips/%s", h.address, request.Question[0].Name)
+
+	httpResponse, err := h.client.Get(url)
+	if err != nil {
+		h.logger.Error(h.logTag, "Error connecting to '%s': %v", h.address, err)
+		responseMsg.SetRcode(request, dns.RcodeServerFailure)
+		return responseMsg
+	}
+	ipsResponsePayload := &ipsResponse{}
+	bytes, err := ioutil.ReadAll(httpResponse.Body)
+	if err != nil {
+		panic("err")
+	}
+	json.Unmarshal(bytes, ipsResponsePayload)
+
+	for _, ip := range ipsResponsePayload.IPs {
+		responseMsg.Answer = append(responseMsg.Answer, &dns.A{
+			Hdr: dns.RR_Header{
+				Name:   request.Question[0].Name,
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    0,
+			},
+			A: net.ParseIP(ip),
+		})
+	}
+	return responseMsg
+}

--- a/src/bosh-dns/dns/server/handlers/http_json_handler.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler.go
@@ -59,7 +59,7 @@ func (h HTTPJSONHandler) ServeDNS(responseWriter dns.ResponseWriter, request *dn
 func (h HTTPJSONHandler) buildResponse(request *dns.Msg) *dns.Msg {
 	responseMsg := new(dns.Msg)
 	responseMsg.Authoritative = true
-	responseMsg.RecursionAvailable = false
+	responseMsg.RecursionAvailable = true
 	responseMsg.SetReply(request)
 
 	if len(request.Question) == 0 {

--- a/src/bosh-dns/dns/server/handlers/http_json_handler.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler.go
@@ -54,7 +54,7 @@ func (h HTTPJSONHandler) buildResponse(request *dns.Msg) *dns.Msg {
 	url := fmt.Sprintf("%s/ips/%s", h.address, request.Question[0].Name)
 
 	httpResponse, err := h.client.Get(url)
-	if err != nil {
+	if err != nil || httpResponse.StatusCode != 200 {
 		h.logger.Error(h.logTag, "Error connecting to '%s': %v", h.address, err)
 		responseMsg.SetRcode(request, dns.RcodeServerFailure)
 		return responseMsg

--- a/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
@@ -90,7 +90,7 @@ var _ = Describe("HttpJsonHandler", func() {
 			Expect(resp.Question).To(Equal(req.Question))
 			Expect(resp.Rcode).To(Equal(dns.RcodeSuccess))
 			Expect(resp.Authoritative).To(BeTrue())
-			Expect(resp.RecursionAvailable).To(BeFalse())
+			Expect(resp.RecursionAvailable).To(BeTrue())
 			Expect(resp.Truncated).To(BeFalse())
 			Expect(resp.Answer).To(HaveLen(2))
 			Expect(resp.Answer[0]).To(Equal(&dns.A{
@@ -121,8 +121,8 @@ var _ = Describe("HttpJsonHandler", func() {
 
 				message := fakeWriter.WriteMsgArgsForCall(0)
 				Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
-				Expect(message.Authoritative).To(Equal(true))
-				Expect(message.RecursionAvailable).To(Equal(false))
+				Expect(message.Authoritative).To(BeTrue())
+				Expect(message.RecursionAvailable).To(BeTrue())
 			})
 		})
 	})
@@ -155,7 +155,7 @@ var _ = Describe("HttpJsonHandler", func() {
 			Expect(resp.Question).To(Equal(req.Question))
 			Expect(resp.Rcode).To(Equal(dns.RcodeServerFailure))
 			Expect(resp.Authoritative).To(BeTrue())
-			Expect(resp.RecursionAvailable).ToNot(BeTrue())
+			Expect(resp.RecursionAvailable).To(BeTrue())
 
 			Expect(resp.Answer).To(HaveLen(0))
 		})
@@ -194,7 +194,7 @@ var _ = Describe("HttpJsonHandler", func() {
 			Expect(resp.Question).To(Equal(req.Question))
 			Expect(resp.Rcode).To(Equal(dns.RcodeServerFailure))
 			Expect(resp.Authoritative).To(BeTrue())
-			Expect(resp.RecursionAvailable).ToNot(BeTrue())
+			Expect(resp.RecursionAvailable).To(BeTrue())
 
 			Expect(resp.Answer).To(HaveLen(0))
 		})
@@ -230,7 +230,7 @@ var _ = Describe("HttpJsonHandler", func() {
 			Expect(resp.Question).To(Equal(req.Question))
 			Expect(resp.Rcode).To(Equal(dns.RcodeServerFailure))
 			Expect(resp.Authoritative).To(BeTrue())
-			Expect(resp.RecursionAvailable).ToNot(BeTrue())
+			Expect(resp.RecursionAvailable).To(BeTrue())
 
 			Expect(resp.Answer).To(HaveLen(0))
 		})
@@ -395,6 +395,7 @@ var _ = Describe("HttpJsonHandler", func() {
 			Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
 			resp := fakeWriter.WriteMsgArgsForCall(0)
 			Expect(resp.Rcode).To(Equal(dns.RcodeSuccess))
+			Expect(resp.RecursionAvailable).To(BeTrue())
 			Expect(resp.Truncated).To(BeTrue())
 			Expect(resp.Question).To(Equal(req.Question))
 			Expect(resp.Answer).To(HaveLen(12))

--- a/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
@@ -15,24 +15,29 @@ import (
 	"github.com/onsi/gomega/ghttp"
 )
 
+func startJsonServerWithHandler(handlerFunc http.HandlerFunc) *ghttp.Server {
+	server := ghttp.NewUnstartedServer()
+	server.AppendHandlers(handlerFunc)
+	server.HTTPTestServer.Start()
+	return server
+}
+
 var _ = Describe("HttpJsonHandler", func() {
 	var (
-		handler    HTTPJSONHandler
-		server     *ghttp.Server
-		fakeLogger *loggerfakes.FakeLogger
-		fakeWriter *internalfakes.FakeResponseWriter
+		handler            HTTPJSONHandler
+		server             *ghttp.Server
+		fakeLogger         *loggerfakes.FakeLogger
+		fakeWriter         *internalfakes.FakeResponseWriter
+		fakeServerResponse http.HandlerFunc
 	)
-	BeforeEach(func() {
-		server = ghttp.NewUnstartedServer()
-		server.AppendHandlers(ghttp.CombineHandlers(
-			ghttp.VerifyRequest("GET", "/ips/app-id.internal-domain."),
-			ghttp.RespondWith(http.StatusOK, `{"ips":["192.168.0.1", "192.168.0.4"]}`),
-		),
-		)
-		server.HTTPTestServer.Start()
 
+	BeforeEach(func() {
 		fakeLogger = &loggerfakes.FakeLogger{}
 		fakeWriter = &internalfakes.FakeResponseWriter{}
+	})
+
+	JustBeforeEach(func() {
+		server = startJsonServerWithHandler(fakeServerResponse)
 		handler = NewHTTPJSONHandler(server.URL(), fakeLogger)
 	})
 
@@ -40,55 +45,65 @@ var _ = Describe("HttpJsonHandler", func() {
 		server.Close()
 	})
 
-	It("returns a DNS response based on answer given by backend server", func() {
-		req := &dns.Msg{}
-		req.SetQuestion("app-id.internal-domain.", dns.TypeA)
+	Context("successful requets", func() {
+		BeforeEach(func() {
+			fakeServerResponse = ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/ips/app-id.internal-domain."),
+				ghttp.RespondWith(http.StatusOK, `{"ips":["192.168.0.1", "192.168.0.4"]}`),
+			)
+		})
 
-		handler.ServeDNS(fakeWriter, req)
+		It("returns a DNS response based on answer given by backend server", func() {
+			req := &dns.Msg{}
+			req.SetQuestion("app-id.internal-domain.", dns.TypeA)
 
-		Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
-		resp := fakeWriter.WriteMsgArgsForCall(0)
-		Expect(resp.Question).To(Equal(req.Question))
-		Expect(resp.Rcode).To(Equal(dns.RcodeSuccess))
-		Expect(resp.Authoritative).To(BeTrue())
-		Expect(resp.RecursionAvailable).ToNot(BeTrue())
+			handler.ServeDNS(fakeWriter, req)
 
-		Expect(resp.Answer).To(HaveLen(2))
-		Expect(resp.Answer[0]).To(Equal(&dns.A{
-			Hdr: dns.RR_Header{
-				Name:   "app-id.internal-domain.",
-				Rrtype: dns.TypeA,
-				Class:  dns.ClassINET,
-				Ttl:    0,
-			},
-			A: net.IPv4(192, 168, 0, 1),
-		}))
+			Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
+			resp := fakeWriter.WriteMsgArgsForCall(0)
+			Expect(resp.Question).To(Equal(req.Question))
+			Expect(resp.Rcode).To(Equal(dns.RcodeSuccess))
+			Expect(resp.Authoritative).To(BeTrue())
+			Expect(resp.RecursionAvailable).ToNot(BeTrue())
 
-		Expect(resp.Answer[1]).To(Equal(&dns.A{
-			Hdr: dns.RR_Header{
-				Name:   "app-id.internal-domain.",
-				Rrtype: dns.TypeA,
-				Class:  dns.ClassINET,
-				Ttl:    0,
-			},
-			A: net.IPv4(192, 168, 0, 4),
-		}))
-	})
+			Expect(resp.Answer).To(HaveLen(2))
+			Expect(resp.Answer[0]).To(Equal(&dns.A{
+				Hdr: dns.RR_Header{
+					Name:   "app-id.internal-domain.",
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				A: net.IPv4(192, 168, 0, 1),
+			}))
 
-	Context("when there are no questions", func() {
-		It("returns rcode success", func() {
-			handler.ServeDNS(fakeWriter, &dns.Msg{})
-			message := fakeWriter.WriteMsgArgsForCall(0)
-			Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
-			Expect(message.Authoritative).To(Equal(true))
-			Expect(message.RecursionAvailable).To(Equal(false))
+			Expect(resp.Answer[1]).To(Equal(&dns.A{
+				Hdr: dns.RR_Header{
+					Name:   "app-id.internal-domain.",
+					Rrtype: dns.TypeA,
+					Class:  dns.ClassINET,
+					Ttl:    0,
+				},
+				A: net.IPv4(192, 168, 0, 4),
+			}))
+		})
+
+		Context("when there are no questions", func() {
+			It("returns rcode success", func() {
+				handler.ServeDNS(fakeWriter, &dns.Msg{})
+				message := fakeWriter.WriteMsgArgsForCall(0)
+				Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
+				Expect(message.Authoritative).To(Equal(true))
+				Expect(message.RecursionAvailable).To(Equal(false))
+			})
 		})
 	})
 
 	Context("when it cannot reach the client", func() {
-		BeforeEach(func() {
+		JustBeforeEach(func() {
 			handler = NewHTTPJSONHandler("bogus-address", fakeLogger)
 		})
+
 		It("logs the error ", func() {
 			req := &dns.Msg{}
 			req.SetQuestion("app-id.internal-domain.", dns.TypeA)
@@ -122,6 +137,7 @@ var _ = Describe("HttpJsonHandler", func() {
 		BeforeEach(func() {
 			fakeWriter.WriteMsgReturns(errors.New("failed to write message"))
 		})
+
 		It("logs the error", func() {
 			handler.ServeDNS(fakeWriter, &dns.Msg{})
 
@@ -133,7 +149,26 @@ var _ = Describe("HttpJsonHandler", func() {
 	})
 
 	Context("when the server responds with non-200", func() {
+		BeforeEach(func() {
+			fakeServerResponse = ghttp.CombineHandlers(
+				ghttp.VerifyRequest("GET", "/ips/app-id.internal-domain."),
+				ghttp.RespondWith(http.StatusNotFound, `{"ips":[]}`),
+			)
+		})
 
+		It("Returns a serve fail response", func() {
+			req := &dns.Msg{}
+			req.SetQuestion("app-id.internal-domain.", dns.TypeA)
+			handler.ServeDNS(fakeWriter, req)
+
+			Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
+			resp := fakeWriter.WriteMsgArgsForCall(0)
+			Expect(resp.Question).To(Equal(req.Question))
+			Expect(resp.Rcode).To(Equal(dns.RcodeServerFailure))
+			Expect(resp.Authoritative).To(BeTrue())
+			Expect(resp.RecursionAvailable).ToNot(BeTrue())
+
+			Expect(resp.Answer).To(HaveLen(0))
+		})
 	})
-
 })

--- a/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
@@ -1,0 +1,139 @@
+package handlers_test
+
+import (
+	. "bosh-dns/dns/server/handlers"
+	"bosh-dns/dns/server/internal/internalfakes"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+
+	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/ghttp"
+)
+
+var _ = Describe("HttpJsonHandler", func() {
+	var (
+		handler    HTTPJSONHandler
+		server     *ghttp.Server
+		fakeLogger *loggerfakes.FakeLogger
+		fakeWriter *internalfakes.FakeResponseWriter
+	)
+	BeforeEach(func() {
+		server = ghttp.NewUnstartedServer()
+		server.AppendHandlers(ghttp.CombineHandlers(
+			ghttp.VerifyRequest("GET", "/ips/app-id.internal-domain."),
+			ghttp.RespondWith(http.StatusOK, `{"ips":["192.168.0.1", "192.168.0.4"]}`),
+		),
+		)
+		server.HTTPTestServer.Start()
+
+		fakeLogger = &loggerfakes.FakeLogger{}
+		fakeWriter = &internalfakes.FakeResponseWriter{}
+		handler = NewHTTPJSONHandler(server.URL(), fakeLogger)
+	})
+
+	AfterEach(func() {
+		server.Close()
+	})
+
+	It("returns a DNS response based on answer given by backend server", func() {
+		req := &dns.Msg{}
+		req.SetQuestion("app-id.internal-domain.", dns.TypeA)
+
+		handler.ServeDNS(fakeWriter, req)
+
+		Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
+		resp := fakeWriter.WriteMsgArgsForCall(0)
+		Expect(resp.Question).To(Equal(req.Question))
+		Expect(resp.Rcode).To(Equal(dns.RcodeSuccess))
+		Expect(resp.Authoritative).To(BeTrue())
+		Expect(resp.RecursionAvailable).ToNot(BeTrue())
+
+		Expect(resp.Answer).To(HaveLen(2))
+		Expect(resp.Answer[0]).To(Equal(&dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "app-id.internal-domain.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    0,
+			},
+			A: net.IPv4(192, 168, 0, 1),
+		}))
+
+		Expect(resp.Answer[1]).To(Equal(&dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "app-id.internal-domain.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    0,
+			},
+			A: net.IPv4(192, 168, 0, 4),
+		}))
+	})
+
+	Context("when there are no questions", func() {
+		It("returns rcode success", func() {
+			handler.ServeDNS(fakeWriter, &dns.Msg{})
+			message := fakeWriter.WriteMsgArgsForCall(0)
+			Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
+			Expect(message.Authoritative).To(Equal(true))
+			Expect(message.RecursionAvailable).To(Equal(false))
+		})
+	})
+
+	Context("when it cannot reach the client", func() {
+		BeforeEach(func() {
+			handler = NewHTTPJSONHandler("bogus-address", fakeLogger)
+		})
+		It("logs the error ", func() {
+			req := &dns.Msg{}
+			req.SetQuestion("app-id.internal-domain.", dns.TypeA)
+			handler.ServeDNS(fakeWriter, req)
+
+			Expect(fakeLogger.ErrorCallCount()).To(Equal(1))
+			tag, template, args := fakeLogger.ErrorArgsForCall(0)
+			Expect(tag).To(Equal("HTTPJSONHandler"))
+			msg := fmt.Sprintf(template, args...)
+			Expect(msg).To(ContainSubstring("Error connecting to 'bogus-address': "))
+			Expect(msg).To(ContainSubstring("Performing GET request"))
+		})
+
+		It("responds with a server fail", func() {
+			req := &dns.Msg{}
+			req.SetQuestion("app-id.internal-domain.", dns.TypeA)
+			handler.ServeDNS(fakeWriter, req)
+
+			Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
+			resp := fakeWriter.WriteMsgArgsForCall(0)
+			Expect(resp.Question).To(Equal(req.Question))
+			Expect(resp.Rcode).To(Equal(dns.RcodeServerFailure))
+			Expect(resp.Authoritative).To(BeTrue())
+			Expect(resp.RecursionAvailable).ToNot(BeTrue())
+
+			Expect(resp.Answer).To(HaveLen(0))
+		})
+	})
+
+	Context("when it cannot write the message", func() {
+		BeforeEach(func() {
+			fakeWriter.WriteMsgReturns(errors.New("failed to write message"))
+		})
+		It("logs the error", func() {
+			handler.ServeDNS(fakeWriter, &dns.Msg{})
+
+			Expect(fakeLogger.ErrorCallCount()).To(Equal(1))
+			tag, msg, _ := fakeLogger.ErrorArgsForCall(0)
+			Expect(tag).To(Equal("HTTPJSONHandler"))
+			Expect(msg).To(Equal("failed to write message"))
+		})
+	})
+
+	Context("when the server responds with non-200", func() {
+
+	})
+
+})

--- a/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
@@ -283,7 +283,7 @@ var _ = Describe("HttpJsonHandler", func() {
 		})
 	})
 
-	Context("when the non truncated http server reponse message is too large to fit in dns message", func() {
+	Context("when the non truncated http server response message is too large to fit in dns message", func() {
 		BeforeEach(func() {
 			fakeWriter.RemoteAddrReturns(&net.UDPAddr{})
 			fakeServerResponse = ghttp.CombineHandlers(

--- a/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/http_json_handler_test.go
@@ -141,7 +141,7 @@ var _ = Describe("HttpJsonHandler", func() {
 			tag, template, args := fakeLogger.ErrorArgsForCall(0)
 			Expect(tag).To(Equal("HTTPJSONHandler"))
 			msg := fmt.Sprintf(template, args...)
-			Expect(msg).To(ContainSubstring("Error connecting to 'bogus-address': "))
+			Expect(msg).To(ContainSubstring("error connecting to 'bogus-address': "))
 			Expect(msg).To(ContainSubstring("Performing GET request"))
 		})
 

--- a/src/bosh-dns/dns/server/records/dnsresolver/function.go
+++ b/src/bosh-dns/dns/server/records/dnsresolver/function.go
@@ -1,0 +1,23 @@
+package dnsresolver
+
+import (
+	"github.com/miekg/dns"
+	"net"
+)
+
+func TruncateIfNeeded(responseWriter dns.ResponseWriter, resp *dns.Msg) {
+	maxLength := dns.MaxMsgSize
+	_, isUDP := responseWriter.RemoteAddr().(*net.UDPAddr)
+
+	if isUDP {
+		maxLength = 512
+	}
+
+	numAnswers := len(resp.Answer)
+
+	for len(resp.Answer) > 0 && resp.Len() > maxLength {
+		resp.Answer = resp.Answer[:len(resp.Answer)-1]
+	}
+
+	resp.Truncated = (isUDP && len(resp.Answer) < numAnswers) || resp.Truncated
+}

--- a/src/bosh-dns/dns/server/records/dnsresolver/local_domain.go
+++ b/src/bosh-dns/dns/server/records/dnsresolver/local_domain.go
@@ -44,7 +44,7 @@ func (d LocalDomain) Resolve(questionDomains []string, responseWriter dns.Respon
 	responseMsg.Authoritative = true
 	responseMsg.RecursionAvailable = false
 
-	d.trimIfNeeded(responseWriter, responseMsg)
+	TruncateIfNeeded(responseWriter, responseMsg)
 
 	return responseMsg
 }
@@ -75,21 +75,4 @@ func (d LocalDomain) resolve(answerDomain string, questionDomains []string) ([]d
 	}
 
 	return d.shuffler.Shuffle(answers), dns.RcodeSuccess
-}
-
-func (LocalDomain) trimIfNeeded(responseWriter dns.ResponseWriter, resp *dns.Msg) {
-	maxLength := dns.MaxMsgSize
-	_, isUDP := responseWriter.RemoteAddr().(*net.UDPAddr)
-
-	if isUDP {
-		maxLength = 512
-	}
-
-	numAnswers := len(resp.Answer)
-
-	for len(resp.Answer) > 0 && resp.Len() > maxLength {
-		resp.Answer = resp.Answer[:len(resp.Answer)-1]
-	}
-
-	resp.Truncated = isUDP && len(resp.Answer) < numAnswers
 }

--- a/src/bosh-dns/test_yml_assets/enable-http-json-endpoints.yml
+++ b/src/bosh-dns/test_yml_assets/enable-http-json-endpoints.yml
@@ -1,0 +1,6 @@
+---
+
+- path: /instance_groups/0/jobs/1/properties?/http_json_endpoints
+  type: replace
+  value:
+    "internal.local.": ((http_json_server_address))

--- a/src/bosh-dns/test_yml_assets/enable-http-json-endpoints.yml
+++ b/src/bosh-dns/test_yml_assets/enable-http-json-endpoints.yml
@@ -1,6 +1,9 @@
 ---
 
-- path: /instance_groups/0/jobs/1/properties?/http_json_endpoints
+- path: /instance_groups/0/jobs/1/properties?/handlers
   type: replace
   value:
-    "internal.local.": ((http_json_server_address))
+    - domain: internal.local.
+      source:
+        type: http
+        url: ((http_json_server_address))


### PR DESCRIPTION
This PR allows BOSH DNS to be configured to direct all queries for a given domain to a http json endpoint. The endpoint is expected to return JSON inspired by google's [DNS-over-HTTPS](https://developers.google.com/speed/public-dns/docs/dns-over-https) JSON format.

