### PR TITLE
Set MaxCacheTtl to 0 for windows2016 stack

### DIFF
--- a/jobs/bosh-dns-windows/templates/pre-start.ps1.erb
+++ b/jobs/bosh-dns-windows/templates/pre-start.ps1.erb
@@ -46,23 +46,8 @@ try {
 
   Get-Service Dnscache | Set-Service -StartupType automatic -PassThru | Start-Service
 <% else %>
-  [int]$Retrycount = "0"
-
-  do {
-    try {
-      Get-Service Dnscache | Stop-Service -PassThru | Set-Service -StartupType disabled
-      Break
-    } catch {
-      if ($Retrycount -gt 120) {
-        Write-Error "Error: could not stop DNS Caching service."
-        Exit 1
-      } else {
-        Write-Host "Could not stop DNS Caching service, retrying in 1 second..."
-        Start-Sleep -Seconds 1
-        $Retrycount = $Retrycount + 1
-      }
-    }
-  } while ($true)
+  $RegistryPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Dnscache\Parameters"
+  Set-ItemProperty -Path $RegistryPath -Name MaxCacheTtl -Value 0 -Type DWord
 <% end %>
 
 Exit 0


### PR DESCRIPTION
Recent release of bosh-dns (+0.0.9) has been shown to not work with Windows2016 stack. This PR fixes the `pre-start`, so that bosh-dns can be deployed with windows2016 stack.

Fixes #6

https://www.pivotaltracker.com/story/show/152544697

Signed-off-by: Sunjay Bhatia <sbhatia@pivotal.io>