### PR TITLE
Set MaxCacheTtl to default when OS caching is on

### DIFF
--- a/jobs/bosh-dns-windows/templates/pre-start.ps1.erb
+++ b/jobs/bosh-dns-windows/templates/pre-start.ps1.erb
@@ -38,7 +38,8 @@ if ($Value.MaxNegativeCacheTtl -ne $ExpectedValue) {
   }
 }
 <% if p('enable_os_dns_caching') %>
-  Remove-ItemProperty -Path $RegistryPath -Name MaxCacheTtl
+  # Reset the MaxCacheTtl to the default: https://technet.microsoft.com/en-us/library/cc959926.aspx
+  Set-ItemProperty -Path $RegistryPath -Name MaxCacheTtl -Value 0x15180 -Type DWord
   $status = (Get-Service Dnscache).Status
   if ($status -ne "Running") {
      Write-Error "Error: Expected Dnscache Service to be Running, got $status"


### PR DESCRIPTION
Fixes the case where MaxCacheTtl was never set so removing the value fails.