### PR TITLE
Set ServerPriorityTimeLimit to 0 on Windows

### DIFF
--- a/jobs/acceptance-tests-windows/spec
+++ b/jobs/acceptance-tests-windows/spec
@@ -14,6 +14,3 @@ properties:
   suites:
     default: .
     description: "Suites to execute within acceptance_tests/windows"
-  properties_to_test.os_caching_enabled:
-    default: false
-    description: "Signal to configure & test disabling system cache"

--- a/jobs/acceptance-tests-windows/templates/run.ps1
+++ b/jobs/acceptance-tests-windows/templates/run.ps1
@@ -10,8 +10,6 @@ go.exe install bosh-dns/vendor/github.com/onsi/ginkgo/ginkgo
 
 Push-Location "${env:GOPATH}\src\bosh-dns\acceptance_tests\windows"
 
-$env:OS_DNS_CACHE = "<%= p('properties_to_test.os_caching_enabled') %>"
-
 ginkgo -randomizeAllSpecs -randomizeSuites -race <%= p('suites') %>
 
 Pop-Location

--- a/jobs/acceptance-tests-windows/templates/run.ps1
+++ b/jobs/acceptance-tests-windows/templates/run.ps1
@@ -1,6 +1,9 @@
 ﻿. C:\var\vcap\packages\golang-1.8-windows\bosh\runtime.ps1
 
-New-Item -Path ${env:GOPATH}\src -ItemType directory
+$ErrorActionPreference = "Stop"
+
+New-Item -Path ${env:GOPATH}\src -ItemType directory -Force
+Remove-Item -recurse -force -erroraction ignore ${env:GOPATH}\src\bosh-dns
 Copy-Item -recurse -force  "C:\var\vcap\packages\acceptance-tests-windows\src\bosh-dns" "$env:GOPATH\src\bosh-dns"
 
 go.exe install bosh-dns/vendor/github.com/onsi/ginkgo/ginkgo
@@ -13,4 +16,4 @@ ginkgo -randomizeAllSpecs -randomizeSuites -race <%= p('suites') %>
 
 Pop-Location
 
-Exit 0
+Exit $LASTEXITCODE

--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -44,10 +44,6 @@ properties:
     description: "Configure ourselves as the system nameserver (e.g. network server addresses will be watched and overwritten)"
     default: true
 
-  enable_os_dns_caching:
-    description: "allow the Windows dns caching service to remain in operation on this VM"
-    default: false
-
   handlers:
     description: "Array of handler configurations"
     default: []

--- a/jobs/bosh-dns-windows/templates/pre-start.ps1.erb
+++ b/jobs/bosh-dns-windows/templates/pre-start.ps1.erb
@@ -37,19 +37,12 @@ if ($Value.MaxNegativeCacheTtl -ne $ExpectedValue) {
     Write-Error "Error: Expected MaxNegativeCacheTtl to be '${ExpectedValue}', got '${Value.MaxNegativeCacheTtl}'"
   }
 }
-<% if p('enable_os_dns_caching') %>
-  # Reset the MaxCacheTtl to the default: https://technet.microsoft.com/en-us/library/cc959926.aspx
-  Set-ItemProperty -Path $RegistryPath -Name MaxCacheTtl -Value 0x15180 -Type DWord
-  $status = (Get-Service Dnscache).Status
-  if ($status -ne "Running") {
-     Write-Error "Error: Expected Dnscache Service to be Running, got $status"
+if ($Value.ServerPriorityTimeLimit -ne $ExpectedValue) {
+  Set-ItemProperty -Path $RegistryPath -Name ServerPriorityTimeLimit -Value $ExpectedValue -Type DWord
+  $Value = Get-ItemProperty -Path $RegistryPath
+  if ($Value.ServerPriorityTimeLimit -ne $ExpectedValue) {
+    Write-Error "Error: Expected ServerPriorityTimeLimit to be '${ExpectedValue}', got '${Value.ServerPriorityTimeLimit}'"
   }
-  $startType = (Get-Service Dnscache).StartType
-  if ($startType -ne "Automatic") {
-     Write-Error "Error: Expected Dnscache StartupType to be Automatic, got $startType"
-  }
-<% else %>
-  Set-ItemProperty -Path $RegistryPath -Name MaxCacheTtl -Value 0 -Type DWord
-<% end %>
+}
 
 Exit 0

--- a/src/bosh-dns/test_yml_assets/windows-acceptance-manifest.yml
+++ b/src/bosh-dns/test_yml_assets/windows-acceptance-manifest.yml
@@ -9,7 +9,7 @@ update:
   update_watch_time: 30000-120000
 
 instance_groups:
-- name: dns-no-system-caching
+- name: acceptance-tests-windows
   azs: [z1]
   instances: 1
   vm_type: large
@@ -21,34 +21,8 @@ instance_groups:
   jobs:
   - name: acceptance-tests-windows
     release: bosh-dns
-    properties:
-      properties_to_test:
-        os_caching_enabled: false
   - name: bosh-dns-windows
     release: bosh-dns
-    properties:
-      enable_os_dns_caching: false
-
-- name: dns-with-system-caching
-  azs: [z1]
-  instances: 1
-  vm_type: large
-  vm_extensions:
-  - 100GB_ephemeral_disk
-  stemcell: default
-  networks:
-  - name: private
-  jobs:
-  - name: acceptance-tests-windows
-    release: bosh-dns
-    properties:
-      properties_to_test:
-        os_caching_enabled: true
-  - name: bosh-dns-windows
-    release: bosh-dns
-    properties:
-      enable_os_dns_caching: true
-
 
 releases:
 - name: bosh-dns


### PR DESCRIPTION
Instead of disabling the Windows DNS cache service (which is not possible in Windows Server 2016), or setting the MaxCacheTtl to 0, just set the ServerPriorityTimeLimit to ensure that BOSH DNS is always tried first.

We already set MaxNegativeCacheTtl, so records should always be looked up in BOSH DNS for internal domains. This will also allow external domains and consul records to be cached, without the need for the enable_os_dns_caching flag.
