### PR TITLE
Add missing files to acceptance-tests-windows package

### DIFF
--- a/packages/acceptance-tests-windows/spec
+++ b/packages/acceptance-tests-windows/spec
@@ -8,6 +8,7 @@ files:
 - bosh-dns/healthcheck/healthclient/*
 - bosh-dns/test_yml_assets/*
 - bosh-dns/vendor/**/*
+- bosh-dns/dns/manager/*
 - exiter.ps1
 
 excluded_files:


### PR DESCRIPTION
bosh-dns/dns/manager is used by the Windows acceptance tests.