### PR TITLE
Set priority of bosh-dns server to 'High'

### DIFF
--- a/jobs/bosh-dns-windows/templates/post-start.ps1.erb
+++ b/jobs/bosh-dns-windows/templates/post-start.ps1.erb
@@ -26,4 +26,7 @@ catch
     $Host.UI.WriteErrorLine($_.Exception.Message)
     Exit 1
 }
+
+(Get-Process -name bosh-dns).PriorityClass='High'
+
 Exit 0

--- a/src/bosh-dns/acceptance_tests/windows/windows_test.go
+++ b/src/bosh-dns/acceptance_tests/windows/windows_test.go
@@ -78,6 +78,16 @@ var _ = Describe("windows tests", func() {
 		Expect(session.Out).To(Say("0"))
 	})
 
+	It("runs the bosh-dns process with High priority", func() {
+		cmd := exec.Command("powershell.exe", "-command", "(Get-Process -name bosh-dns).PriorityClass")
+		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+		Expect(err).NotTo(HaveOccurred())
+
+		Eventually(session, 10*time.Second).Should(gexec.Exit(0))
+
+		Expect(session.Out).To(Say("High"))
+	})
+
 	It("sets the DNS cache service server priority time limit to 0", func() {
 		cmd := exec.Command("powershell.exe", "$Value = Get-ItemProperty -Path HKLM:\\SYSTEM\\CurrentControlSet\\Services\\Dnscache\\Parameters; $Value.ServerPriorityTimeLimit")
 		session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)


### PR DESCRIPTION
If the CPU is under load (99-100%) DNS lookups for internal CF
components (through bosh-dns) will time out. By raising the priority of the
bosh-dns process, we can ensure that it is never starved of CPU,
preventing the timeouts