### PR TITLE
Pass the interface name to powershell to set DNS

### DIFF
--- a/src/bosh-dns/dns/manager/syscall_windows.go
+++ b/src/bosh-dns/dns/manager/syscall_windows.go
@@ -42,6 +42,7 @@ func (WindowsAdapterFetcher) Adapters() ([]Adapter, error) {
 			OperStatus:         aa.OperStatus,
 			UnicastAddresses:   ipsFromSocketAddresses(socketAddressesFromIpAdapterUnicastAddress(aa.FirstUnicastAddress)),
 			DNSServerAddresses: ipsFromSocketAddresses(socketAddressesFromIpAdapterDnsServerAdapter(aa.FirstDnsServerAddress)),
+			FriendlyName: syscall.UTF16ToString((*(*[10000]uint16)(unsafe.Pointer(aa.FriendlyName)))[:]),
 		})
 	}
 	return aas, nil


### PR DESCRIPTION
This PR fixes an issue where in some IaaSes (e.g. Azure) `Get-WmiObject Win32_NetworkAdapter` query in powershell returns the nat interface instead of the physical adapter. We now know the real physical adapter from #19 which could be used when running `prependDNSServer.ps1`.

We weren't able to install all the necessary dependencies to run all of the unit tests, but `manager` package unit tests still pass.

Since starting a powershell process is expensive, in future releases we should find an equivalent syscall or registry key that changes DNS servers instead.