### PR TITLE
Add spec property to allow bosh-dns to be run as root

### DIFF
--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -126,3 +126,7 @@ properties:
   health.max_tracked_queries:
     description: "Maximum number of DNS resolved FQDNs to maintain live health info for"
     default: 2000
+
+  experimental_run_as_root:
+    description: "Execute the bosh-dns process as root"
+    default: false

--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -56,7 +56,7 @@ function start_dns() {
   ulimit -n 65536
 
   pushd ${JOB_DIR}
-  chpst -u vcap:vcap \
+  <% unless p('experimental_run_as_root') %>chpst -u vcap:vcap \<% end %>
     "${DNS_PACKAGE}/bin/bosh-dns" \
     --config "${JOB_DIR}/config/config.json" \
     1>> ${LOG_DIR}/bosh_dns.stdout.log \


### PR DESCRIPTION
The cfdev team will soon migrate to the [bosh-runc-cpi](https://github.com/aemengo/bosh-runc-cpi-release) as its primary bosh interface. However, we've noticed that the bosh-dns process abruptly fails to start when invoked during pre-start (not during the monit job) during CF deploys in our environment. An easy resolution for us is to have the ability to run the process as root.