### PR TITLE
Make handler configuration example correct

### DIFF
--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -73,18 +73,18 @@ properties:
     description: "Array of handler configurations"
     default: []
     example:
-      - domain: local.internal.
+      - domain: endpoint.local.
         cache:
           enabled: true
         source:
           type: http
           url: http://some.endpoint.local
-      - domain: local.internal2.
+      - domain: corp.intranet.local.
         cache:
           enabled: true
         source:
           type: dns
-          recursors: [ 127.0.0.1 ]
+          recursors: [ 10.0.0.2 ]
 
   handlers_files_glob:
     description: "Glob for any files to look for DNS handler information"


### PR DESCRIPTION
In the first example given, the domain is set to `local.internal.`
and the `url` is set to `endpoint.local`. In the second, the domain
is set to `local.internal2.` Given that `.local` is a common TLD,
the example is confusing because it implies that the DNS names should
be listed in reverse order (akin to Java packages). This PR corrects
the first case, and hopefully makes both examples more readable.