### PR TITLE
Reducing default number of logs

### DIFF
--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -44,7 +44,7 @@ properties:
     default: 53
   log_level:
     description: Logging level (DEBUG, INFO, WARN, ERROR, NONE)
-    default: DEBUG
+    default: INFO
 
   api.port:
     description: "Port that the DNS servers debug API will listen on"

--- a/src/bosh-dns/dns/server/handlers/request_logger_handler.go
+++ b/src/bosh-dns/dns/server/handlers/request_logger_handler.go
@@ -47,7 +47,7 @@ func (h RequestLoggerHandler) ServeDNS(responseWriter dns.ResponseWriter, req *d
 		types[i] = fmt.Sprintf("%d", q.Qtype)
 		domains[i] = q.Name
 	}
-	h.logger.Info(h.logTag, fmt.Sprintf("%T Request [%s] [%s] %d %dns",
+	h.logger.Debug(h.logTag, fmt.Sprintf("%T Request [%s] [%s] %d %dns",
 		h.Handler,
 		strings.Join(types, ","),
 		strings.Join(domains, ","),


### PR DESCRIPTION
Before this change I had (cf-deployment) to many logs like that:
```
[RequestLoggerHandler] 2020/01/02 16:17:02 INFO - handlers.DiscoveryHandler Request [16] [q-s0.doppler.default.cf.bosh.] 2 23697ns
[RequestLoggerHandler] 2020/01/02 16:17:02 INFO - handlers.DiscoveryHandler Request [33] [_grpclb._tcp.q-s0.doppler.default.cf.bosh.] 2 19171ns
```
This is small change that reduces this logs.