### PR TITLE
Add an optional upcheck validation for internal domains

### DIFF
--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -123,6 +123,10 @@ properties:
     default:
       - upcheck.bosh-dns.
 
+  internal_upcheck_domain.enabled:
+    description: "Enables an upcheck, which validates that internal domain resolution is working"
+    default: false
+
   health.enabled:
     description: "Enable healthchecks for DNS resolution"
     default: false

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -36,6 +36,10 @@
   cache: {
     enabled: p('cache.enabled')
   },
-  handlers_files_glob: p('handlers_files_glob')
+  handlers_files_glob: p('handlers_files_glob'),
+  internal_upcheck_domain: {
+    enabled: p('internal_upcheck_domain.enabled'),
+    dns_query: "q-i#{spec.index}.#{spec.name}.*.#{spec.deployment}.bosh."
+  }
 }.to_json
 %>

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -130,6 +130,10 @@ properties:
     default:
       - upcheck.bosh-dns.
 
+  internal_upcheck_domain.enabled:
+    description: "Enables an upcheck, which validates that internal domain resolution is working"
+    default: false
+
   health.enabled:
     description: "Enable healthchecks for DNS resolution"
     default: false

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -36,6 +36,10 @@
   cache: {
     enabled: p('cache.enabled')
   },
-  handlers_files_glob: p('handlers_files_glob')
+  handlers_files_glob: p('handlers_files_glob'),
+  internal_upcheck_domain: {
+    enabled: p('internal_upcheck_domain.enabled'),
+    dns_query: "q-i#{spec.index}.#{spec.name}.*.#{spec.deployment}.bosh."
+  }
 }.to_json
 %>

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -37,9 +37,10 @@ type Config struct {
 
 	API APIConfig `json:"api"`
 
-	Health  HealthConfig  `json:"health"`
-	Metrics MetricsConfig `json:"metrics"`
-	Cache   Cache         `json:"cache"`
+	Health                HealthConfig          `json:"health"`
+	Metrics               MetricsConfig         `json:"metrics"`
+	Cache                 Cache                 `json:"cache"`
+	InternalUpcheckDomain InternalUpcheckDomain `json:"internal_upcheck_domain"`
 }
 
 func (c Config) GetLogLevel() (boshlog.LogLevel, error) {
@@ -75,6 +76,11 @@ type MetricsConfig struct {
 
 type Cache struct {
 	Enabled bool `json:"enabled"`
+}
+
+type InternalUpcheckDomain struct {
+	Enabled  bool   `json:"enabled"`
+	DNSQuery string `json:"dns_query"`
 }
 
 type DurationJSON time.Duration

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -107,6 +107,10 @@ var _ = Describe("Config", func() {
 			"cache": map[string]interface{}{
 				"enabled": true,
 			},
+			"internal_upcheck_domain": map[string]interface{}{
+				"enabled":   true,
+				"dns_query": "internal.test.query.",
+			},
 			"handlers": []map[string]interface{}{{
 				"domain": "some.tld.",
 				"cache": map[string]interface{}{
@@ -174,6 +178,10 @@ var _ = Describe("Config", func() {
 			},
 			Cache: config.Cache{
 				Enabled: true,
+			},
+			InternalUpcheckDomain: config.InternalUpcheckDomain{
+				Enabled:  true,
+				DNSQuery: "internal.test.query.",
 			},
 		}))
 	})

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -183,6 +183,10 @@ func mainExitCode() int {
 		for _, addr := range listenAddrs {
 			upchecks = append(upchecks, server.NewDNSAnswerValidatingUpcheck(addr, upcheckDomain, "udp", logger))
 			upchecks = append(upchecks, server.NewDNSAnswerValidatingUpcheck(addr, upcheckDomain, "tcp", logger))
+			if config.InternalUpcheckDomain.Enabled {
+				upchecks = append(upchecks, server.NewInternalDNSAnswerValidatingUpcheck(addr, config.InternalUpcheckDomain.DNSQuery, "udp", logger))
+				upchecks = append(upchecks, server.NewInternalDNSAnswerValidatingUpcheck(addr, config.InternalUpcheckDomain.DNSQuery, "tcp", logger))
+			}
 		}
 	}
 


### PR DESCRIPTION
If the validation is activated bosh-dns will periodically check
that the internal domain resolution works. If it doesn't work
will restart itself.