### PR TITLE
Log failed recurser requests at Error level

### DIFF
--- a/src/bosh-dns/dns/server/handlers/forward_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler_test.go
@@ -130,18 +130,21 @@ var _ = Describe("ForwardHandler", func() {
 				recursionHandler.ServeDNS(fakeWriter, msg)
 				Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
 
-				Expect(fakeLogger.DebugCallCount()).To(Equal(4))
-				tag, logMsg, args := fakeLogger.DebugArgsForCall(1)
+				Expect(fakeLogger.ErrorCallCount()).To(Equal(2))
+				Expect(fakeLogger.DebugCallCount()).To(Equal(2))
+				tag, logMsg, args := fakeLogger.ErrorArgsForCall(0)
 				Expect(tag).To(Equal("ForwardHandler"))
-				Expect(logMsg).To(Equal("error recursing to %q: %s"))
-				Expect(args[0]).To(Equal("127.0.0.1"))
-				Expect(args[1]).To(Equal("first recursor failed to reply"))
-				tag, logMsg, args = fakeLogger.DebugArgsForCall(2)
+				Expect(logMsg).To(Equal("error recursing for %s to %q: %s"))
+				Expect(args[0]).To(Equal("example.com."))
+				Expect(args[1]).To(Equal("127.0.0.1"))
+				Expect(args[2]).To(Equal("first recursor failed to reply"))
+				tag, logMsg, args = fakeLogger.ErrorArgsForCall(1)
 				Expect(tag).To(Equal("ForwardHandler"))
-				Expect(logMsg).To(Equal("error recursing to %q: %s"))
-				Expect(args[0]).To(Equal("10.244.5.4"))
-				Expect(args[1]).To(Equal("first recursor failed to reply"))
-				tag, logMsg, _ = fakeLogger.DebugArgsForCall(3)
+				Expect(logMsg).To(Equal("error recursing for %s to %q: %s"))
+				Expect(args[0]).To(Equal("example.com."))
+				Expect(args[1]).To(Equal("10.244.5.4"))
+				Expect(args[2]).To(Equal("first recursor failed to reply"))
+				tag, logMsg, _ = fakeLogger.DebugArgsForCall(1)
 				Expect(tag).To(Equal("ForwardHandler"))
 				Expect(logMsg).To(Equal(fmt.Sprintf("handlers.ForwardHandler Request id=%d qtype=[ANY] qname=[example.com.] rcode=NXDOMAIN ancount=0 error=[first recursor failed to reply] time=0ns", msg.Id)))
 
@@ -158,8 +161,8 @@ var _ = Describe("ForwardHandler", func() {
 
 					recursionHandler.ServeDNS(fakeWriter, msg)
 
-					Expect(fakeLogger.ErrorCallCount()).To(Equal(1))
-					tag, msg, args := fakeLogger.ErrorArgsForCall(0)
+					Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
+					tag, msg, args := fakeLogger.ErrorArgsForCall(2)
 					Expect(tag).To(Equal("ForwardHandler"))
 					Expect(fmt.Sprintf(msg, args...)).To(Equal("error writing response: failed to write message"))
 				})
@@ -284,14 +287,15 @@ var _ = Describe("ForwardHandler", func() {
 				})
 
 				It("writes a failure result", func() {
-					Expect(fakeLogger.DebugCallCount()).To(Equal(4))
-					tag, msg, args := fakeLogger.DebugArgsForCall(1)
+					Expect(fakeLogger.DebugCallCount()).To(Equal(2))
+					Expect(fakeLogger.ErrorCallCount()).To(Equal(2))
+					tag, msg, args := fakeLogger.ErrorArgsForCall(0)
 					Expect(tag).To(Equal("ForwardHandler"))
-					Expect(fmt.Sprintf(msg, args...)).To(Equal(`error recursing to "127.0.0.1": failed to exchange`))
+					Expect(fmt.Sprintf(msg, args...)).To(Equal(`error recursing for example.com. to "127.0.0.1": failed to exchange`))
 
-					tag, msg, args = fakeLogger.DebugArgsForCall(2)
+					tag, msg, args = fakeLogger.ErrorArgsForCall(1)
 					Expect(tag).To(Equal("ForwardHandler"))
-					Expect(fmt.Sprintf(msg, args...)).To(Equal(`error recursing to "10.244.5.4": failed to exchange`))
+					Expect(fmt.Sprintf(msg, args...)).To(Equal(`error recursing for example.com. to "10.244.5.4": failed to exchange`))
 				})
 
 				Context("when all recursors fail", func() {


### PR DESCRIPTION
Current version of bosh-dns requires DEBUG level for recursor errors.
It is not easy to reproduce recursor errors and DEBUG level is too noisy
as production configuration. That is why it will be better to log
recursor failures at ERROR level. This change will log all recursor
errors at ERROR level beside the "NXDOMAIN" errror, which I think is
easy for debugging and could be too noise.

To test the new log level execute following commands on a BOSH VM, where bosh-dns is running:
```
iptables -A INPUT -p udp -s <recursor-ip> -j DROP
iptables -A INPUT -p tcp -s <recursor-ip> -j DROP

nslookup <public-domain>

# in ==> bosh_dns.stdout.log <==
[ForwardHandler] 2020/05/07 16:45:49 ERROR - error recursing for <public-domain>. to "<recursor-ip>:53": read udp <instance-ip>:33697-><recursor-ip>:53: i/o timeout
```

fixises #60