### PR TITLE
Metrics address can be set, defaults to loopback

### DIFF
--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -118,6 +118,10 @@ properties:
     description: "Internal port for metrics server to listen to"
     default: 53088
 
+  metrics.address:
+    description: "Address for metrics server to bind to"
+    default: 127.0.0.1
+
   upcheck_domains:
     description: "Domain names that the dns server should respond to with successful answers. Answer ip will always be 127.0.0.1"
     default:

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -31,7 +31,8 @@
   },
   metrics: {
     enabled: p('metrics.enabled'),
-    port: p('metrics.port')
+    port: p('metrics.port'),
+    address: p('metrics.address')
   },
   cache: {
     enabled: p('cache.enabled')

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -122,8 +122,12 @@ properties:
     default: false
 
   metrics.port:
-    description: "Internal port for metrics server to listen to"
+    description: "Port for metrics server to listen to"
     default: 53088
+
+  metrics.address:
+    description: "Address for metrics server to bind to"
+    default: 127.0.0.1
 
   upcheck_domains:
     description: "Domain names that the dns server should respond to with successful answers. Answer ip will always be 127.0.0.1"

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -31,7 +31,8 @@
   },
   metrics: {
     enabled: p('metrics.enabled'),
-    port: p('metrics.port')
+    port: p('metrics.port'),
+    address: p('metrics.address')
   },
   cache: {
     enabled: p('cache.enabled')

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -70,8 +70,9 @@ type HealthConfig struct {
 }
 
 type MetricsConfig struct {
-	Enabled bool `json:"enabled"`
-	Port    int  `json:"port"`
+	Enabled bool   `json:"enabled"`
+	Address string `json:"address"`
+	Port    int    `json:"port"`
 }
 
 type Cache struct {
@@ -120,6 +121,7 @@ func NewDefaultConfig() Config {
 		},
 		Metrics: MetricsConfig{
 			Enabled: false,
+			Address: "127.0.0.1",
 			Port:    53088,
 		},
 		LogLevel: boshlog.AsString(boshlog.LevelDebug),

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -196,7 +196,7 @@ func mainExitCode() int {
 		metricsServerWrapper *monitoring.MetricsServerWrapper
 	)
 	if config.Metrics.Enabled {
-		metricsAddr := fmt.Sprintf("127.0.0.1:%d", config.Metrics.Port)
+		metricsAddr := fmt.Sprintf("%s:%d", config.Metrics.Address, config.Metrics.Port)
 		metricsServerWrapper = monitoring.NewMetricsServerWrapper(logger, monitoring.MetricsServer(metricsAddr))
 		nextExternalHandler = handlers.NewMetricsDNSHandler(metricsServerWrapper.MetricsReporter(), nextExternalHandler)
 		nextInternalHandler = handlers.NewMetricsDNSHandler(metricsServerWrapper.MetricsReporter(), nextInternalHandler)

--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -262,6 +262,7 @@ var _ = Describe("main", func() {
 
 			cfg.Metrics = config.MetricsConfig{
 				Enabled: metricsEnabled,
+				Address: "127.0.0.1",
 				Port:    53088 + ginkgoconfig.GinkgoConfig.ParallelNode,
 			}
 


### PR DESCRIPTION
What
----

As a Prometheus user, I want Prometheus to scrape BOSH DNS from another instance, so that I can get metrics, without a local scraper

In order to get a remote Prometheus to scrape BOSH DNS, the metrics server must listen on external interfaces.

Keep the default to 127.0.0.1 so this won't change behaviour