### PR TITLE
Fix metrics reporting to also report return codes correctly.

### DIFF
--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -195,14 +195,14 @@ func mainExitCode() int {
 		nextExternalHandler  dns.Handler = forwardHandler
 		metricsServerWrapper *monitoring.MetricsServerWrapper
 	)
-	if config.Metrics.Enabled {
-		metricsAddr := fmt.Sprintf("%s:%d", config.Metrics.Address, config.Metrics.Port)
-		metricsServerWrapper = monitoring.NewMetricsServerWrapper(logger, monitoring.MetricsServer(metricsAddr))
-		nextExternalHandler = handlers.NewMetricsDNSHandler(metricsServerWrapper.MetricsReporter(), nextExternalHandler)
-		nextInternalHandler = handlers.NewMetricsDNSHandler(metricsServerWrapper.MetricsReporter(), nextInternalHandler)
-	}
 	if config.Cache.Enabled {
 		nextExternalHandler = handlers.NewCachingDNSHandler(nextExternalHandler, truncater, clock, logger)
+	}
+	if config.Metrics.Enabled {
+		metricsAddr := fmt.Sprintf("%s:%d", config.Metrics.Address, config.Metrics.Port)
+		metricsServerWrapper = monitoring.NewMetricsServerWrapper(logger, monitoring.MetricsServer(metricsAddr, nextInternalHandler, nextExternalHandler))
+		nextExternalHandler = handlers.NewMetricsDNSHandler(metricsServerWrapper.MetricsReporter(), monitoring.DNSRequestTypeExternal)
+		nextInternalHandler = handlers.NewMetricsDNSHandler(metricsServerWrapper.MetricsReporter(), monitoring.DNSRequestTypeInternal)
 	}
 	mux.Handle(".", nextExternalHandler)
 

--- a/src/bosh-dns/dns/server/handlers/metrics_handler.go
+++ b/src/bosh-dns/dns/server/handlers/metrics_handler.go
@@ -4,22 +4,21 @@ import (
 	"bosh-dns/dns/server/monitoring"
 
 	"github.com/miekg/dns"
-	"golang.org/x/net/context"
 )
 
 type MetricsDNSHandler struct {
 	metricsReporter monitoring.MetricsReporter
-	next            dns.Handler
+	requestType     monitoring.DNSRequestType
 }
 
-func NewMetricsDNSHandler(metricsReporter monitoring.MetricsReporter, next dns.Handler) MetricsDNSHandler {
+func NewMetricsDNSHandler(metricsReporter monitoring.MetricsReporter, requestType monitoring.DNSRequestType) MetricsDNSHandler {
 	return MetricsDNSHandler{
 		metricsReporter: metricsReporter,
-		next:            next,
+		requestType: requestType,
 	}
 }
 
 func (m MetricsDNSHandler) ServeDNS(w dns.ResponseWriter, r *dns.Msg) {
-	m.metricsReporter.Report(context.Background(), w, r)
-	m.next.ServeDNS(w, r)
+	requestContext := monitoring.NewRequestContext(m.requestType)
+	m.metricsReporter.Report(requestContext, w, r)
 }

--- a/src/bosh-dns/dns/server/monitoring/dns_request_type.go
+++ b/src/bosh-dns/dns/server/monitoring/dns_request_type.go
@@ -1,0 +1,55 @@
+package monitoring
+
+import (
+	"context"
+	"errors"
+	"github.com/miekg/dns"
+)
+
+// DNSRequestType defines which type of dns request is handled
+type DNSRequestType string
+type key int
+
+const(
+	// DNSRequestTypeInternal is used for internal dns requests
+	DNSRequestTypeInternal DNSRequestType = "internal"
+	// DNSRequestTypeExternal is used for external dns requests
+	DNSRequestTypeExternal DNSRequestType = "external"
+
+	dnsRequestContext key = iota
+)
+
+// NewRequestContext Creates a new context for the given request typeß
+func NewRequestContext(t DNSRequestType) context.Context {
+	return context.WithValue(context.Background(), dnsRequestContext, t)
+}
+
+// NewPluginHandlerAdapter creates a new PluginHandler for both internal and external dns requests
+func NewPluginHandlerAdapter(internalHandler dns.Handler, externalHandler dns.Handler) pluginHandlerAdapter {
+	return pluginHandlerAdapter{internalHandler: internalHandler, externalHandler: externalHandler}
+}
+
+type pluginHandlerAdapter struct {
+	internalHandler dns.Handler
+	externalHandler dns.Handler
+}
+
+func(p pluginHandlerAdapter) Name() string {
+	return "pluginHandlerAdapter"
+}
+
+func(p pluginHandlerAdapter) ServeDNS(ctx context.Context, writer dns.ResponseWriter, m *dns.Msg) (int, error) {
+	v := ctx.Value(dnsRequestContext)
+
+	if v == nil {
+		return 0, errors.New("No DNS request type found in context")
+	}
+
+	if p.externalHandler != nil && v == DNSRequestTypeExternal {
+		p.externalHandler.ServeDNS(writer, m)
+	} else if p.internalHandler != nil && v == DNSRequestTypeInternal {
+		p.internalHandler.ServeDNS(writer, m)
+	}
+	return 0, nil
+}
+

--- a/src/bosh-dns/dns/server/monitoring/dns_request_type_test.go
+++ b/src/bosh-dns/dns/server/monitoring/dns_request_type_test.go
@@ -1,0 +1,61 @@
+package monitoring_test
+
+import (
+	"bosh-dns/dns/server/handlers/handlersfakes"
+	"bosh-dns/dns/server/internal/internalfakes"
+	"bosh-dns/dns/server/monitoring"
+
+	"context"
+
+	"github.com/miekg/dns"
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("DNSRequestType", func() {
+	var (
+		fakeInternalDnsHandler handlersfakes.FakeDNSHandler
+		fakeExternalDnsHandler handlersfakes.FakeDNSHandler
+
+		fakeWriter internalfakes.FakeResponseWriter
+		request    dns.Msg
+	)
+
+	BeforeEach(func() {
+		fakeInternalDnsHandler = handlersfakes.FakeDNSHandler{}
+		fakeExternalDnsHandler = handlersfakes.FakeDNSHandler{}
+
+		fakeWriter = internalfakes.FakeResponseWriter{}
+		request = dns.Msg{}
+	})
+
+	It("redirects internal dns requests", func() {
+		pluginHandler := monitoring.NewPluginHandlerAdapter(&fakeInternalDnsHandler, &fakeExternalDnsHandler)
+
+		internal := monitoring.NewRequestContext(monitoring.DNSRequestTypeInternal)
+		pluginHandler.ServeDNS(internal, &fakeWriter, &request)
+
+		Expect(fakeInternalDnsHandler.ServeDNSCallCount()).To(Equal(1))
+		Expect(fakeExternalDnsHandler.ServeDNSCallCount()).To(Equal(0))
+	})
+
+	It("redirects external dns requests", func() {
+		pluginHandler := monitoring.NewPluginHandlerAdapter(&fakeInternalDnsHandler, &fakeExternalDnsHandler)
+
+		external := monitoring.NewRequestContext(monitoring.DNSRequestTypeExternal)
+		pluginHandler.ServeDNS(external, &fakeWriter, &request)
+
+		Expect(fakeInternalDnsHandler.ServeDNSCallCount()).To(Equal(0))
+		Expect(fakeExternalDnsHandler.ServeDNSCallCount()).To(Equal(1))
+	})
+
+	It("redirects no dns requests without information in context", func() {
+		pluginHandler := monitoring.NewPluginHandlerAdapter(&fakeInternalDnsHandler, &fakeExternalDnsHandler)
+
+		pluginHandler.ServeDNS(context.Background(), &fakeWriter, &request)
+
+		Expect(fakeInternalDnsHandler.ServeDNSCallCount()).To(Equal(0))
+		Expect(fakeExternalDnsHandler.ServeDNSCallCount()).To(Equal(0))
+	})
+
+})

--- a/src/bosh-dns/dns/server/monitoring/metrics_server.go
+++ b/src/bosh-dns/dns/server/monitoring/metrics_server.go
@@ -36,8 +36,10 @@ func NewMetricsServerWrapper(logger boshlog.Logger, server CoreDNSMetricsServer)
 	}
 }
 
-func MetricsServer(listenAddress string) CoreDNSMetricsServer {
-	return metrics.New(listenAddress)
+func MetricsServer(listenAddress string, internalDNSHandler dns.Handler, externalDNSHandler dns.Handler) CoreDNSMetricsServer {
+	m := metrics.New(listenAddress)
+	m.Next = pluginHandlerAdapter{internalHandler: internalDNSHandler, externalHandler: externalDNSHandler}
+	return m
 }
 
 func (m *MetricsServerWrapper) MetricsReporter() MetricsReporter {

--- a/src/bosh-dns/dns/server/monitoring/metrics_server_test.go
+++ b/src/bosh-dns/dns/server/monitoring/metrics_server_test.go
@@ -4,7 +4,6 @@ import (
 	"bosh-dns/dns/server/internal/internalfakes"
 	"bosh-dns/dns/server/monitoring"
 	"bosh-dns/dns/server/monitoring/monitoringfakes"
-	"context"
 	"errors"
 
 	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
@@ -64,21 +63,21 @@ var _ = Describe("MetricsServerWrapper", func() {
 
 	Describe("Report", func() {
 		var (
-			metritcsReporter monitoring.MetricsReporter
+			metricsReporter monitoring.MetricsReporter
 			metricsServer    monitoring.CoreDNSMetricsServer
 			fakeWriter       *internalfakes.FakeResponseWriter
 		)
 
 		BeforeEach(func() {
 			fakeWriter = &internalfakes.FakeResponseWriter{}
-			metricsServer = monitoring.MetricsServer("127.0.0.1:53088")
-			metritcsReporter = monitoring.NewMetricsServerWrapper(fakeLogger, metricsServer).MetricsReporter()
+			metricsServer = monitoring.MetricsServer("127.0.0.1:53088", nil, nil)
+			metricsReporter = monitoring.NewMetricsServerWrapper(fakeLogger, metricsServer).MetricsReporter()
 		})
 
 		It("collects metrics", func() {
 			m := &dns.Msg{}
 
-			metritcsReporter.Report(context.Background(), fakeWriter, m)
+			metricsReporter.Report(monitoring.NewRequestContext(monitoring.DNSRequestTypeExternal), fakeWriter, m)
 
 			Expect(findMetric(metricsServer, "coredns_dns_requests_total")).To(Equal(1.0))
 			Expect(findMetric(metricsServer, "coredns_dns_responses_total")).To(Equal(1.0))


### PR DESCRIPTION
The return codes were always reported as NOERROR because the was no
handler called inside the metrics handler where the return code could be
recorded.

So instead of calling all handlers in serial (metrics, cache, forward),
the metrics handler calls the next handler during reporting
(metrics[cache, forward]).

This only applies if reporting metrics is enabled.
