### PR TITLE
Reverse lookup for aliases

### DIFF
--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -932,6 +932,20 @@ var _ = Describe("main", func() {
 						Expect(len(r.Answer)).To(Equal(1))
 						Expect(r.Answer[0].(*dns.PTR).Ptr).To(Equal("primer-instance.my-group.my-network.my-deployment.primer."))
 					})
+
+					It("responds with alias records", func(){
+						m.SetQuestion("1.0.0.127.in-addr.arpa.", dns.TypePTR)
+						r, _, err := c.Exchange(m, fmt.Sprintf("%s:%d", listenAddress, listenPort))
+
+						Expect(err).NotTo(HaveOccurred())
+						Expect(r.Rcode).To(Equal(dns.RcodeSuccess))
+						Expect(len(r.Answer)).To(Equal(3))
+						var answers []string
+						for _, answer := range r.Answer {
+							answers = append(answers, answer.(*dns.PTR).Ptr)
+						}
+						Expect(answers).To(Equal([]string{"my-instance.my-group.my-network.my-deployment.bosh", "one.alias.", "internal.alias."}))
+					})
 				})
 
 				It("logs handler time", func() {

--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -944,7 +944,7 @@ var _ = Describe("main", func() {
 						for _, answer := range r.Answer {
 							answers = append(answers, answer.(*dns.PTR).Ptr)
 						}
-						Expect(answers).To(Equal([]string{"my-instance.my-group.my-network.my-deployment.bosh", "one.alias.", "internal.alias."}))
+						Expect(answers).To(Equal([]string{"my-instance.my-group.my-network.my-deployment.bosh.", "one.alias.", "internal.alias."}))
 					})
 				})
 

--- a/src/bosh-dns/dns/server/aliases/config.go
+++ b/src/bosh-dns/dns/server/aliases/config.go
@@ -129,28 +129,17 @@ func (c Config) Resolutions(maybeAlias string) []string {
 }
 
 func (c Config) DomainResolutions(domain string) []string {
-   var resolveAlias []string
+   var exactMatchAliases []string
     for alias, domains := range c.aliases {
         for _, aliasDomain := range domains {
 			if aliasDomain == domain {
-                  resolveAlias = append(resolveAlias, alias)
+                  exactMatchAliases = append(exactMatchAliases, alias)
                   break
            }
         }
     }
 
-    //for alias, domains := range c.underscoreAliases {
-    //    for _, aliasDomain := range domains {
-    //       if aliasDomain == domain {
-    //              underscoreAlias := "_." + alias
-    //              resolveAlias = append(resolveAlias, underscoreAlias)
-    //              break
-    //       }
-    //    }
-    //}
-
-
-    return resolveAlias
+    return exactMatchAliases
 }
 
 

--- a/src/bosh-dns/dns/server/aliases/config.go
+++ b/src/bosh-dns/dns/server/aliases/config.go
@@ -128,6 +128,32 @@ func (c Config) Resolutions(maybeAlias string) []string {
 	return nil
 }
 
+func (c Config) DomainResolutions(domain string) []string {
+   var resolveAlias []string
+    for alias, domains := range c.aliases {
+        for _, aliasDomain := range domains {
+			if aliasDomain == domain {
+                  resolveAlias = append(resolveAlias, alias)
+                  break
+           }
+        }
+    }
+
+    //for alias, domains := range c.underscoreAliases {
+    //    for _, aliasDomain := range domains {
+    //       if aliasDomain == domain {
+    //              underscoreAlias := "_." + alias
+    //              resolveAlias = append(resolveAlias, underscoreAlias)
+    //              break
+    //       }
+    //    }
+    //}
+
+
+    return resolveAlias
+}
+
+
 func (c Config) Merge(other Config) Config {
 	for alias, targets := range other.aliases {
 		if _, found := c.aliases[alias]; found {

--- a/src/bosh-dns/dns/server/aliases/config.go
+++ b/src/bosh-dns/dns/server/aliases/config.go
@@ -128,7 +128,7 @@ func (c Config) Resolutions(maybeAlias string) []string {
 	return nil
 }
 
-func (c Config) DomainResolutions(domain string) []string {
+func (c Config) AliasResolutions(domain string) []string {
    var exactMatchAliases []string
     for alias, domains := range c.aliases {
         for _, aliasDomain := range domains {

--- a/src/bosh-dns/dns/server/aliases/config_test.go
+++ b/src/bosh-dns/dns/server/aliases/config_test.go
@@ -176,6 +176,22 @@ var _ = Describe("Config", func() {
 		})
 	})
 
+	Describe("DomainResolutions", func() {
+		It("resolves a FQDNs to the aliases that match", func() {
+
+			c := MustNewConfigFromMap(map[string][]string{
+				"something.alias":    {"domain"},
+				"alias-wildcard":     {"*.domain"},
+				"_.alias-underscore": {"_.domain"},
+			})
+
+			Expect(c.DomainResolutions("domain.")).To(Equal([]string{"something.alias."}))
+			// TODO: Do we need to match on * and _ aliases? How do we handle healthiness checks?
+			//Expect(c.DomainResolutions("1.domain.")).To(Equal([]string{"alias-wildcard", "1.alias-underscore"}))
+		})
+
+	})
+
 	Describe("Merge", func() {
 		Context("when the target is an empty config", func() {
 			It("presents the original config", func() {

--- a/src/bosh-dns/dns/server/aliases/config_test.go
+++ b/src/bosh-dns/dns/server/aliases/config_test.go
@@ -176,13 +176,21 @@ var _ = Describe("Config", func() {
 		})
 	})
 
-	Describe("DomainResolutions", func() {
+	Describe("AliasResolutions", func() {
 		It("resolves a FQDNs to the aliases that match", func() {
 			c := MustNewConfigFromMap(map[string][]string{
 				"something.alias":    {"domain"},
 			})
 
-			Expect(c.DomainResolutions("domain.")).To(Equal([]string{"something.alias."}))
+			Expect(c.AliasResolutions("domain.")).To(Equal([]string{"something.alias."}))
+		})
+
+		It("resolves an ip to aliases that match", func() {
+			c := MustNewConfigFromMap(map[string][]string{
+				"something.alias":    {"1.1.1.1"},
+			})
+
+			Expect(c.AliasResolutions("1.1.1.1")).To(Equal([]string{"something.alias."}))
 		})
 
 		It("does not resolve underscored or wildcard domains", func() {
@@ -192,7 +200,7 @@ var _ = Describe("Config", func() {
 				"_.alias-underscore": {"_.domain"},
 			})
 
-			Expect(c.DomainResolutions("1.domain.")).To(Equal([]string{}))
+			Expect(c.AliasResolutions("1.domain.")).To(BeEmpty())
 		})
 
 	})

--- a/src/bosh-dns/dns/server/aliases/config_test.go
+++ b/src/bosh-dns/dns/server/aliases/config_test.go
@@ -178,16 +178,21 @@ var _ = Describe("Config", func() {
 
 	Describe("DomainResolutions", func() {
 		It("resolves a FQDNs to the aliases that match", func() {
-
 			c := MustNewConfigFromMap(map[string][]string{
 				"something.alias":    {"domain"},
-				"alias-wildcard":     {"*.domain"},
-				"_.alias-underscore": {"_.domain"},
 			})
 
 			Expect(c.DomainResolutions("domain.")).To(Equal([]string{"something.alias."}))
-			// TODO: Do we need to match on * and _ aliases? How do we handle healthiness checks?
-			//Expect(c.DomainResolutions("1.domain.")).To(Equal([]string{"alias-wildcard", "1.alias-underscore"}))
+		})
+
+		It("does not resolve underscored or wildcard domains", func() {
+			c := MustNewConfigFromMap(map[string][]string{
+				"alias-wildcard":     {"*.domain"},
+				"query-alias":     {"q-s0.domain"},
+				"_.alias-underscore": {"_.domain"},
+			})
+
+			Expect(c.DomainResolutions("1.domain.")).To(Equal([]string{}))
 		})
 
 	})

--- a/src/bosh-dns/dns/server/handlers/arpa_handler.go
+++ b/src/bosh-dns/dns/server/handlers/arpa_handler.go
@@ -86,7 +86,7 @@ func (a ArpaHandler) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	fqdns := a.ipProvider.GetFQDNsAndAliases(ip)
+	fqdns := a.ipProvider.GetFQDNs(ip)
 	if fqdns != nil && len(fqdns) > 0 {
 		m.SetRcode(req, dns.RcodeSuccess)
 		for _, fqdn := range fqdns {

--- a/src/bosh-dns/dns/server/handlers/arpa_handler.go
+++ b/src/bosh-dns/dns/server/handlers/arpa_handler.go
@@ -86,7 +86,7 @@ func (a ArpaHandler) ServeDNS(w dns.ResponseWriter, req *dns.Msg) {
 		return
 	}
 
-	fqdns := a.ipProvider.GetFQDNs(ip)
+	fqdns := a.ipProvider.GetFQDNsAndAliases(ip)
 	if fqdns != nil && len(fqdns) > 0 {
 		m.SetRcode(req, dns.RcodeSuccess)
 		for _, fqdn := range fqdns {

--- a/src/bosh-dns/dns/server/records/record_set.go
+++ b/src/bosh-dns/dns/server/records/record_set.go
@@ -240,7 +240,7 @@ func (r *RecordSet) HasIP(ip string) bool {
 	return false
 }
 
-func (r *RecordSet) GetFQDNsAndAliases(ip string) []string {
+func (r *RecordSet) GetFQDNs(ip string) []string {
 	r.recordsMutex.RLock()
 	defer r.recordsMutex.RUnlock()
 

--- a/src/bosh-dns/dns/server/records/record_set.go
+++ b/src/bosh-dns/dns/server/records/record_set.go
@@ -245,12 +245,15 @@ func (r *RecordSet) GetFQDNs(ip string) []string {
 	defer r.recordsMutex.RUnlock()
 
 	uniqueFqnds := make(map[string]bool)
+	for _, alias := range r.mergedAliasList.AliasResolutions(ip) {
+		uniqueFqnds[alias] = true
+	}
 
 	for _, host := range r.hosts {
 		if host.IP == ip {
 			domain := dns.Fqdn(host.FQDN)
 			uniqueFqnds[domain] = true
-			for _, alias := range r.mergedAliasList.DomainResolutions(domain) {
+			for _, alias := range r.mergedAliasList.AliasResolutions(domain) {
 				uniqueFqnds[alias] = true
 			}
 

--- a/src/bosh-dns/dns/server/records/record_set_test.go
+++ b/src/bosh-dns/dns/server/records/record_set_test.go
@@ -342,6 +342,7 @@ var _ = Describe("RecordSet", func() {
 		BeforeEach(func() {
 			aliasList = mustNewConfigFromMap(map[string][]string{
 				"alias1": {"instance0.my-group.my-network.my-deployment.withadot"},
+				"alias2": {"123.123.123.124"},
 			})
 		})
 
@@ -368,8 +369,8 @@ var _ = Describe("RecordSet", func() {
 			recordSet, err = records.NewRecordSet(fileReader, aliasList, fakeHealthWatcher, uint(5), shutdownChan, fakeLogger, fakeFiltererFactory, fakeAliasQueryEncoder)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(recordSet.GetFQDNs("123.123.123.123")).To(Equal([]string{"instance0.my-group.my-network.my-deployment.withadot.", "alias1.", "0.my-group.my-network.my-deployment.withadot."}))
-			Expect(recordSet.GetFQDNs("123.123.123.124")).To(Equal([]string{"instance1.my-group.my-network.my-deployment.nodot.", "1.my-group.my-network.my-deployment.nodot."}))
+			Expect(recordSet.GetFQDNs("123.123.123.123")).To(ConsistOf("alias1.", "instance0.my-group.my-network.my-deployment.withadot.", "0.my-group.my-network.my-deployment.withadot."))
+			Expect(recordSet.GetFQDNs("123.123.123.124")).To(ConsistOf("instance1.my-group.my-network.my-deployment.nodot.", "1.my-group.my-network.my-deployment.nodot.", "alias2."))
 			Expect(recordSet.GetFQDNs("123.123.123.125")).To(Equal([]string{"instance2.my-group.my-network.my-deployment.domain.", "2.my-group.my-network.my-deployment.domain."}))
 			Expect(recordSet.GetFQDNs("127.0.0.1")).To(BeEmpty())
 		})

--- a/src/bosh-dns/dns/server/records/record_set_test.go
+++ b/src/bosh-dns/dns/server/records/record_set_test.go
@@ -44,7 +44,7 @@ var _ = Describe("RecordSet", func() {
 		aliasList             aliases.Config
 		shutdownChan          chan struct{}
 		fakeHealthWatcher     *healthinessfakes.FakeHealthWatcher
-		fakeQueryFilterer    *recordsfakes.FakeFilterer
+		fakeQueryFilterer     *recordsfakes.FakeFilterer
 		fakeHealthFilterer    *recordsfakes.FakeFilterer
 		fakeFiltererFactory   *recordsfakes.FakeFiltererFactory
 		fakeAliasQueryEncoder *recordsfakes.FakeAliasQueryEncoder
@@ -338,10 +338,13 @@ var _ = Describe("RecordSet", func() {
 		})
 	})
 
-	Describe("GetFQDNs", func() {
+	Describe("GetFQDNsAndAliases", func() {
 		BeforeEach(func() {
 			aliasList = mustNewConfigFromMap(map[string][]string{
-				"alias1": {""},
+				"alias1": {"instance0.my-group.my-network.my-deployment.withadot"},
+				// Todo: Ignoreing wildcard and underscore matches for now
+				//"alias2": {"_.my-group.my-network.my-deployment.withadot"},
+				//"alias3": {"*.my-group.my-network.my-deployment.withadot"},
 			})
 		})
 
@@ -368,10 +371,10 @@ var _ = Describe("RecordSet", func() {
 			recordSet, err = records.NewRecordSet(fileReader, aliasList, fakeHealthWatcher, uint(5), shutdownChan, fakeLogger, fakeFiltererFactory, fakeAliasQueryEncoder)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(recordSet.GetFQDNs("123.123.123.123")).To(Equal([]string{"instance0.my-group.my-network.my-deployment.withadot.", "0.my-group.my-network.my-deployment.withadot."}))
-			Expect(recordSet.GetFQDNs("123.123.123.124")).To(Equal([]string{"instance1.my-group.my-network.my-deployment.nodot.", "1.my-group.my-network.my-deployment.nodot."}))
-			Expect(recordSet.GetFQDNs("123.123.123.125")).To(Equal([]string{"instance2.my-group.my-network.my-deployment.domain.", "2.my-group.my-network.my-deployment.domain."}))
-			Expect(recordSet.GetFQDNs("127.0.0.1")).To(BeEmpty())
+			Expect(recordSet.GetFQDNsAndAliases("123.123.123.123")).To(Equal([]string{"instance0.my-group.my-network.my-deployment.withadot.", "alias1.", "0.my-group.my-network.my-deployment.withadot."}))
+			Expect(recordSet.GetFQDNsAndAliases("123.123.123.124")).To(Equal([]string{"instance1.my-group.my-network.my-deployment.nodot.", "1.my-group.my-network.my-deployment.nodot."}))
+			Expect(recordSet.GetFQDNsAndAliases("123.123.123.125")).To(Equal([]string{"instance2.my-group.my-network.my-deployment.domain.", "2.my-group.my-network.my-deployment.domain."}))
+			Expect(recordSet.GetFQDNsAndAliases("127.0.0.1")).To(BeEmpty())
 		})
 	})
 
@@ -1330,7 +1333,7 @@ var _ = Describe("RecordSet", func() {
 				go func() {
 					defer GinkgoRecover()
 					for j := 0; j < 10; j++ {
-						domains := recordSet.GetFQDNs("123.123.123.123")
+						domains := recordSet.GetFQDNsAndAliases("123.123.123.123")
 						Expect(domains).To(ConsistOf("instance0.my-group.my-network.my-deployment.domain."))
 					}
 					wg.Done()

--- a/src/bosh-dns/dns/server/records/record_set_test.go
+++ b/src/bosh-dns/dns/server/records/record_set_test.go
@@ -338,13 +338,10 @@ var _ = Describe("RecordSet", func() {
 		})
 	})
 
-	Describe("GetFQDNsAndAliases", func() {
+	Describe("GetFQDNs", func() {
 		BeforeEach(func() {
 			aliasList = mustNewConfigFromMap(map[string][]string{
 				"alias1": {"instance0.my-group.my-network.my-deployment.withadot"},
-				// Todo: Ignoreing wildcard and underscore matches for now
-				//"alias2": {"_.my-group.my-network.my-deployment.withadot"},
-				//"alias3": {"*.my-group.my-network.my-deployment.withadot"},
 			})
 		})
 
@@ -371,10 +368,10 @@ var _ = Describe("RecordSet", func() {
 			recordSet, err = records.NewRecordSet(fileReader, aliasList, fakeHealthWatcher, uint(5), shutdownChan, fakeLogger, fakeFiltererFactory, fakeAliasQueryEncoder)
 			Expect(err).ToNot(HaveOccurred())
 
-			Expect(recordSet.GetFQDNsAndAliases("123.123.123.123")).To(Equal([]string{"instance0.my-group.my-network.my-deployment.withadot.", "alias1.", "0.my-group.my-network.my-deployment.withadot."}))
-			Expect(recordSet.GetFQDNsAndAliases("123.123.123.124")).To(Equal([]string{"instance1.my-group.my-network.my-deployment.nodot.", "1.my-group.my-network.my-deployment.nodot."}))
-			Expect(recordSet.GetFQDNsAndAliases("123.123.123.125")).To(Equal([]string{"instance2.my-group.my-network.my-deployment.domain.", "2.my-group.my-network.my-deployment.domain."}))
-			Expect(recordSet.GetFQDNsAndAliases("127.0.0.1")).To(BeEmpty())
+			Expect(recordSet.GetFQDNs("123.123.123.123")).To(Equal([]string{"instance0.my-group.my-network.my-deployment.withadot.", "alias1.", "0.my-group.my-network.my-deployment.withadot."}))
+			Expect(recordSet.GetFQDNs("123.123.123.124")).To(Equal([]string{"instance1.my-group.my-network.my-deployment.nodot.", "1.my-group.my-network.my-deployment.nodot."}))
+			Expect(recordSet.GetFQDNs("123.123.123.125")).To(Equal([]string{"instance2.my-group.my-network.my-deployment.domain.", "2.my-group.my-network.my-deployment.domain."}))
+			Expect(recordSet.GetFQDNs("127.0.0.1")).To(BeEmpty())
 		})
 	})
 
@@ -1333,7 +1330,7 @@ var _ = Describe("RecordSet", func() {
 				go func() {
 					defer GinkgoRecover()
 					for j := 0; j < 10; j++ {
-						domains := recordSet.GetFQDNsAndAliases("123.123.123.123")
+						domains := recordSet.GetFQDNs("123.123.123.123")
 						Expect(domains).To(ConsistOf("instance0.my-group.my-network.my-deployment.domain."))
 					}
 					wg.Done()


### PR DESCRIPTION
This PR addresses https://github.com/cloudfoundry/bosh-dns-release/issues/72

With a job aliases.json file that looks pseudo-ish like this:
a: 123.group.vm (pretend this is the FQDNs)
b: q-s0.group.vm (returns all vms in an instance group that are healty)
c: *.group.vm (wildcard on instance group)
_d: _.group.vm (vm1d would match vm1.group.vm)
e: 123.group.vm, 234.group.vm (two FQDNs)
f: 1.1.1.1 

All of these aliases potentially could resolve to 1.1.1.1. This PR will change a reverse ip lookup on 1.1.1.1 from only returning the FQDNS to returning a, e and f as well. It will match on exact FQDNs's or ips in the alias values and ignore the others.
