### PR TITLE
bosh-dns recursor retry

### DIFF
--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -95,7 +95,7 @@ properties:
   recursor_timeout:
     description: "A timeout value for when dialing, writing and reading from the configured recursors"
     default: 2s
-  recursor_retry_count:
+  recursor_max_retries:
     description: "Maximum number of retries for recursively resolving DNS queries"
     default: 0
   recursor_selection:

--- a/jobs/bosh-dns-windows/spec
+++ b/jobs/bosh-dns-windows/spec
@@ -95,6 +95,9 @@ properties:
   recursor_timeout:
     description: "A timeout value for when dialing, writing and reading from the configured recursors"
     default: 2s
+  recursor_retry_count:
+    description: "Maximum number of retries for recursively resolving DNS queries"
+    default: 0
   recursor_selection:
     description: "The selection strategy for the recursors (serial or smart)"
     default: smart

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -10,7 +10,7 @@
   alias_files_glob: p('alias_files_glob'),
   upcheck_domains: p('upcheck_domains'),
   recursor_timeout: p('recursor_timeout'),
-  recursor_retry_count: p('recursor_retry_count'),
+  recursor_max_retries: p('recursor_max_retries'),
   request_timeout: p('request_timeout'),
   recursor_selection: p('recursor_selection'),
   jobs_dir: '/var/vcap/jobs',

--- a/jobs/bosh-dns-windows/templates/config.json.erb
+++ b/jobs/bosh-dns-windows/templates/config.json.erb
@@ -10,6 +10,7 @@
   alias_files_glob: p('alias_files_glob'),
   upcheck_domains: p('upcheck_domains'),
   recursor_timeout: p('recursor_timeout'),
+  recursor_retry_count: p('recursor_retry_count'),
   request_timeout: p('request_timeout'),
   recursor_selection: p('recursor_selection'),
   jobs_dir: '/var/vcap/jobs',

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -102,7 +102,7 @@ properties:
   recursor_timeout:
     description: "A timeout value for when dialing, writing and reading from the configured recursors"
     default: 2s
-  recursor_retry_count:
+  recursor_max_retries:
     description: "Maximum number of retries for recursively resolving DNS queries"
     default: 0
   recursor_selection:

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -102,6 +102,9 @@ properties:
   recursor_timeout:
     description: "A timeout value for when dialing, writing and reading from the configured recursors"
     default: 2s
+  recursor_retry_count:
+    description: "Maximum number of retries for recursively resolving DNS queries"
+    default: 0
   recursor_selection:
     description: "The selection strategy for the recursors (serial or smart)"
     default: smart

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -10,7 +10,7 @@
   alias_files_glob: p('alias_files_glob'),
   upcheck_domains: p('upcheck_domains'),
   recursor_timeout: p('recursor_timeout'),
-  recursor_retry_count: p('recursor_retry_count'),
+  recursor_max_retries: p('recursor_max_retries'),
   request_timeout: p('request_timeout'),
   recursor_selection: p('recursor_selection'),
   jobs_dir: '/var/vcap/jobs',

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -10,6 +10,7 @@
   alias_files_glob: p('alias_files_glob'),
   upcheck_domains: p('upcheck_domains'),
   recursor_timeout: p('recursor_timeout'),
+  recursor_retry_count: p('recursor_retry_count'),
   request_timeout: p('request_timeout'),
   recursor_selection: p('recursor_selection'),
   jobs_dir: '/var/vcap/jobs',

--- a/spec/jobs/shared_examples.rb
+++ b/spec/jobs/shared_examples.rb
@@ -23,16 +23,16 @@ shared_examples_for 'common config.json' do
       end
     end
 
-    context 'recursor_retry_count' do
+    context 'recursor_max_retries' do
       it 'defaults to 0' do
-        expect(rendered['recursor_retry_count']).to eq(0)
+        expect(rendered['recursor_max_retries']).to eq(0)
       end
 
       context 'configured' do
-        let(:properties) { {'recursor_retry_count' => 3} }
+        let(:properties) { {'recursor_max_retries' => 3} }
 
-        it 'writes recursor_retry_count' do
-          expect(rendered['recursor_retry_count']).to eq(3)
+        it 'writes recursor_max_retries' do
+          expect(rendered['recursor_max_retries']).to eq(3)
         end
       end
     end

--- a/spec/jobs/shared_examples.rb
+++ b/spec/jobs/shared_examples.rb
@@ -22,5 +22,19 @@ shared_examples_for 'common config.json' do
         end
       end
     end
+
+    context 'recursor_retry_count' do
+      it 'defaults to 0' do
+        expect(rendered['recursor_retry_count']).to eq(0)
+      end
+
+      context 'configured' do
+        let(:properties) { {'recursor_retry_count' => 3} }
+
+        it 'writes recursor_retry_count' do
+          expect(rendered['recursor_retry_count']).to eq(3)
+        end
+      end
+    end
   end
 end

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -22,7 +22,7 @@ type Config struct {
 	Address            string       `json:"address"`
 	Port               int          `json:"port"`
 	BindTimeout        DurationJSON `json:"timeout,omitempty"`
-	RecursorRetryCount int          `json:"recursor_retry_count,omitempty"`
+	RecursorMaxRetries int          `json:"recursor_max_retries,omitempty"`
 	RequestTimeout     DurationJSON `json:"request_timeout,omitempty"`
 	RecursorTimeout    DurationJSON `json:"recursor_timeout,omitempty"`
 	Recursors          []string     `json:"recursors,omitempty"`

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -22,6 +22,7 @@ type Config struct {
 	Address            string       `json:"address"`
 	Port               int          `json:"port"`
 	BindTimeout        DurationJSON `json:"timeout,omitempty"`
+	RecursorRetryCount int          `json:"recursor_retry_count,omitempty"`
 	RequestTimeout     DurationJSON `json:"request_timeout,omitempty"`
 	RecursorTimeout    DurationJSON `json:"recursor_timeout,omitempty"`
 	Recursors          []string     `json:"recursors,omitempty"`

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -162,7 +162,7 @@ var _ = Describe("Config", func() {
 				CAFile:          apiCAFile,
 			},
 			BindTimeout:        config.DurationJSON(timeoutDuration),
-			RecursorRetryCount: 0,
+			RecursorMaxRetries: 0,
 			RequestTimeout:     config.DurationJSON(requestTimeoutDuration),
 			RecursorTimeout:    config.DurationJSON(recursorTimeoutDuration),
 			Recursors:          []string{},
@@ -279,20 +279,20 @@ var _ = Describe("Config", func() {
 			Expect(err).To(MatchError("invalid value for recursor_selection; expected 'serial' or 'smart'"))
 		})
 
-		It("recursor_retry_count default", func() {
+		It("recursor_max_retries default", func() {
 			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53, "recursor_selection": "smart" }`)
 
 			c, err := config.LoadFromFile(configFilePath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(c.RecursorRetryCount).To(Equal(0))
+			Expect(c.RecursorMaxRetries).To(Equal(0))
 		})
 
-		It("recursor_retry_count with value", func() {
-			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53, "recursor_selection": "smart", "recursor_retry_count": 3 }`)
+		It("recursor_max_retries with value", func() {
+			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53, "recursor_selection": "smart", "recursor_max_retries": 3 }`)
 
 			c, err := config.LoadFromFile(configFilePath)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(c.RecursorRetryCount).To(Equal(3))
+			Expect(c.RecursorMaxRetries).To(Equal(3))
 		})
 	})
 

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -162,6 +162,7 @@ var _ = Describe("Config", func() {
 				CAFile:          apiCAFile,
 			},
 			BindTimeout:        config.DurationJSON(timeoutDuration),
+			RecursorRetryCount: 0,
 			RequestTimeout:     config.DurationJSON(requestTimeoutDuration),
 			RecursorTimeout:    config.DurationJSON(recursorTimeoutDuration),
 			Recursors:          []string{},
@@ -276,6 +277,22 @@ var _ = Describe("Config", func() {
 
 			_, err := config.LoadFromFile(configFilePath)
 			Expect(err).To(MatchError("invalid value for recursor_selection; expected 'serial' or 'smart'"))
+		})
+
+		It("recursor_retry_count default", func() {
+			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53, "recursor_selection": "smart" }`)
+
+			c, err := config.LoadFromFile(configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.RecursorRetryCount).To(Equal(0))
+		})
+
+		It("recursor_retry_count with value", func() {
+			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53, "recursor_selection": "smart", "recursor_retry_count": 3 }`)
+
+			c, err := config.LoadFromFile(configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(c.RecursorRetryCount).To(Equal(3))
 		})
 	})
 

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -158,7 +158,7 @@ func mainExitCode() int {
 	truncater := dnsresolver.NewResponseTruncater()
 	localDomain := dnsresolver.NewLocalDomain(logger, recordSet, shuffle.New(), truncater)
 
-	recursorPool := handlers.NewFailoverRecursorPool(config.Recursors, config.RecursorSelection, config.RecursorRetryCount, logger)
+	recursorPool := handlers.NewFailoverRecursorPool(config.Recursors, config.RecursorSelection, config.RecursorMaxRetries, logger)
 	exchangerFactory := handlers.NewExchangerFactory(time.Duration(config.RecursorTimeout))
 	forwardHandler := handlers.NewForwardHandler(recursorPool, exchangerFactory, clock, logger, truncater)
 

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -158,7 +158,7 @@ func mainExitCode() int {
 	truncater := dnsresolver.NewResponseTruncater()
 	localDomain := dnsresolver.NewLocalDomain(logger, recordSet, shuffle.New(), truncater)
 
-	recursorPool := handlers.NewFailoverRecursorPool(config.Recursors, config.RecursorSelection, logger)
+	recursorPool := handlers.NewFailoverRecursorPool(config.Recursors, config.RecursorSelection, config.RecursorRetryCount, logger)
 	exchangerFactory := handlers.NewExchangerFactory(time.Duration(config.RecursorTimeout))
 	forwardHandler := handlers.NewForwardHandler(recursorPool, exchangerFactory, clock, logger, truncater)
 

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -164,7 +164,7 @@ func mainExitCode() int {
 
 	mux.Handle("arpa.", handlers.NewRequestLoggerHandler(handlers.NewArpaHandler(logger, recordSet, forwardHandler), clock, logger))
 
-	handlerFactory := handlers.NewFactory(exchangerFactory, clock, stringShuffler, logger, truncater)
+	handlerFactory := handlers.NewFactory(exchangerFactory, clock, stringShuffler, config.RecursorRetryCount, logger, truncater)
 
 	delegatingHandlers, err := handlersConfiguration.GenerateHandlers(handlerFactory)
 	if err != nil {

--- a/src/bosh-dns/dns/main.go
+++ b/src/bosh-dns/dns/main.go
@@ -164,7 +164,7 @@ func mainExitCode() int {
 
 	mux.Handle("arpa.", handlers.NewRequestLoggerHandler(handlers.NewArpaHandler(logger, recordSet, forwardHandler), clock, logger))
 
-	handlerFactory := handlers.NewFactory(exchangerFactory, clock, stringShuffler, config.RecursorRetryCount, logger, truncater)
+	handlerFactory := handlers.NewFactory(exchangerFactory, clock, stringShuffler, config.RecursorMaxRetries, logger, truncater)
 
 	delegatingHandlers, err := handlersConfiguration.GenerateHandlers(handlerFactory)
 	if err != nil {

--- a/src/bosh-dns/dns/server/handlers/factory.go
+++ b/src/bosh-dns/dns/server/handlers/factory.go
@@ -49,7 +49,7 @@ func (f *Factory) CreateForwardHandler(recursors []string, cache bool) dns.Handl
 	//
 	// The default behavior defined by DNS spec is to use
 	// "smart" recursor selection.
-	pool := NewFailoverRecursorPool(f.shuffler.Shuffle(recursors), config.SmartRecursorSelection, f.logger)
+	pool := NewFailoverRecursorPool(f.shuffler.Shuffle(recursors), config.SmartRecursorSelection, 0, f.logger)
 	handler = NewForwardHandler(pool, f.exchangerFactory, f.clock, f.logger, f.truncater)
 
 	if cache {

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
@@ -132,10 +132,9 @@ func performWithRetryLogic(work func(string) error, recursor string, retryCount 
 			return err
 		}
 		if _, ok := err.(net.Error); !ok {
-			log.Debug(logTag, fmt.Sprintf("dns request error %v no retry - %v\n", err, recursor))
 			return err
 		}
-		log.Error(logTag, fmt.Sprintf("dns request network error %s retry [%d/%d] for recoursor %s \n", err.(net.Error), ret+1, retryCount, recursor))
+		log.Debug(logTag, fmt.Sprintf("dns request network error %s retry [%d/%d] for recoursor %s \n", err.(net.Error), ret+1, retryCount, recursor))
 	}
 
 	//retry count reached r

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
@@ -126,7 +126,7 @@ func (q *serialFailoverRecursorPool) PerformStrategically(work func(string) erro
 }
 
 func performWithRetryLogic(work func(string) error, recursor string, retryCount int, logTag string, log logger.Logger) (err error) {
-	for ret := -1; ret < retryCount; ret++ {
+	for ret := 0; ret <= retryCount; ret++ {
 		err = work(recursor)
 		if err == nil {
 			return err
@@ -134,10 +134,10 @@ func performWithRetryLogic(work func(string) error, recursor string, retryCount 
 		if _, ok := err.(net.Error); !ok {
 			return err
 		}
-		log.Debug(logTag, fmt.Sprintf("dns request network error %s retry [%d/%d] for recoursor %s \n", err.(net.Error), ret+1, retryCount, recursor))
+		log.Debug(logTag, fmt.Sprintf("dns request network error %s retry [%d/%d] for recursor %s \n", err.(net.Error), ret+1, retryCount, recursor))
 	}
 
-	//retry count reached r
+	//retry count reached
 	log.Error(logTag, fmt.Sprintf("write error response to client after retry count reached [%d/%d] with rcode=%d - %s \n", retryCount, retryCount, dns.RcodeServerFailure, err.Error()))
 	return err
 }

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
@@ -134,7 +134,7 @@ func performWithRetryLogic(work func(string) error, recursor string, maxRetries 
 		if _, ok := err.(net.Error); !ok {
 			return err
 		}
-		log.Debug(logTag, fmt.Sprintf("dns request network error %s retry [%d/%d] for recursor %s \n", err.(net.Error), ret+1, maxRetries, recursor))
+		log.Debug(logTag, fmt.Sprintf("dns request network error %s retry [%d/%d] - request count [%d] for recursor %s \n", err.(net.Error), ret, maxRetries, ret+1, recursor))
 	}
 
 	//retry count reached

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool_test.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool_test.go
@@ -41,7 +41,7 @@ var _ = Describe("RecursorPool", func() {
 				"three": 0,
 			}
 
-			pool := NewFailoverRecursorPool([]string{"one", "two", "three"}, config.SerialRecursorSelection, fakeLogger)
+			pool := NewFailoverRecursorPool([]string{"one", "two", "three"}, config.SerialRecursorSelection, 0, fakeLogger)
 			err := pool.PerformStrategically(work(recursorCallCount))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(recursorCallCount).To(Equal(map[string]int{
@@ -50,7 +50,7 @@ var _ = Describe("RecursorPool", func() {
 				"three": 0,
 			}))
 
-			pool = NewFailoverRecursorPool([]string{"bad", "two", "three"}, config.SerialRecursorSelection, fakeLogger)
+			pool = NewFailoverRecursorPool([]string{"bad", "two", "three"}, config.SerialRecursorSelection, 0, fakeLogger)
 			err = pool.PerformStrategically(work(recursorCallCount))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(recursorCallCount).To(Equal(map[string]int{
@@ -59,7 +59,7 @@ var _ = Describe("RecursorPool", func() {
 				"three": 0,
 			}))
 
-			pool = NewFailoverRecursorPool([]string{"bad", "bad", "three"}, config.SerialRecursorSelection, fakeLogger)
+			pool = NewFailoverRecursorPool([]string{"bad", "bad", "three"}, config.SerialRecursorSelection, 0, fakeLogger)
 			err = pool.PerformStrategically(work(recursorCallCount))
 			Expect(err).NotTo(HaveOccurred())
 			Expect(recursorCallCount).To(Equal(map[string]int{
@@ -74,7 +74,7 @@ var _ = Describe("RecursorPool", func() {
 
 			BeforeEach(func() {
 				fakeLogger := &loggerfakes.FakeLogger{}
-				pool = NewFailoverRecursorPool([]string{"bad", "bad", "bad"}, config.SerialRecursorSelection, fakeLogger)
+				pool = NewFailoverRecursorPool([]string{"bad", "bad", "bad"}, config.SerialRecursorSelection, 0, fakeLogger)
 			})
 
 			It("fails when all recursors fail", func() {
@@ -132,14 +132,14 @@ var _ = Describe("RecursorPool", func() {
 				}
 			}
 
-			pool = NewFailoverRecursorPool(recursors, config.SmartRecursorSelection, fakeLogger)
+			pool = NewFailoverRecursorPool(recursors, config.SmartRecursorSelection, 0, fakeLogger)
 		})
 
 		It("returns an error if there are no recursors configured", func() {
-			pool = NewFailoverRecursorPool([]string{}, config.SmartRecursorSelection, fakeLogger)
+			pool = NewFailoverRecursorPool([]string{}, config.SmartRecursorSelection, 0, fakeLogger)
 			Expect(pool.PerformStrategically(func(string) error { return nil })).To(HaveOccurred())
 
-			pool = NewFailoverRecursorPool(nil, config.SmartRecursorSelection, fakeLogger)
+			pool = NewFailoverRecursorPool(nil, config.SmartRecursorSelection, 0, fakeLogger)
 			Expect(pool.PerformStrategically(func(string) error { return nil })).To(HaveOccurred())
 		})
 

--- a/src/bosh-dns/dns/server/handlers/forward_handler.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler.go
@@ -114,10 +114,8 @@ func (r ForwardHandler) writeNoResponseMessage(responseWriter dns.ResponseWriter
 
 	switch err.(type) {
 	case net.Error:
-		if err.(net.Error).Timeout() {
-			responseMessage.SetRcode(req, dns.RcodeServerFailure)
-			break
-		}
+		r.logger.Error(r.logTag, fmt.Sprintf("received a network error from server rcode=%d - %s", dns.RcodeServerFailure, err.Error()))
+		responseMessage.SetRcode(req, dns.RcodeServerFailure)
 	default:
 		responseMessage.SetRcode(req, dns.RcodeNameError)
 		break

--- a/src/bosh-dns/dns/server/handlers/forward_handler.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler.go
@@ -114,7 +114,6 @@ func (r ForwardHandler) writeNoResponseMessage(responseWriter dns.ResponseWriter
 
 	switch err.(type) {
 	case net.Error:
-		r.logger.Error(r.logTag, fmt.Sprintf("received a network error from server rcode=%d - %s", dns.RcodeServerFailure, err.Error()))
 		responseMessage.SetRcode(req, dns.RcodeServerFailure)
 	default:
 		responseMessage.SetRcode(req, dns.RcodeNameError)

--- a/src/bosh-dns/dns/server/handlers/forward_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler_test.go
@@ -1,6 +1,7 @@
 package handlers_test
 
 import (
+	"bosh-dns/dns/config"
 	"bosh-dns/dns/server/records/dnsresolver/dnsresolverfakes"
 	"errors"
 	"net"
@@ -241,6 +242,143 @@ var _ = Describe("ForwardHandler", func() {
 				Entry("forwards query to recursor via udp for udp clients", "udp", nil),
 				Entry("forwards query to recursor via tcp for tcp clients", "tcp", &net.TCPAddr{}),
 			)
+
+			Context("i/o timout without retry", func() {
+				var (
+					requestMessage *dns.Msg
+				)
+
+				BeforeEach(func() {
+					fakeExchanger := &handlersfakes.FakeExchanger{}
+					fakeExchangerFactory := func(net string) handlers.Exchanger { return fakeExchanger }
+					recursionHandler = handlers.NewForwardHandler(fakeRecursorPool, fakeExchangerFactory, fakeClock, fakeLogger, fakeTruncater)
+					requestMessage = &dns.Msg{}
+					requestMessage.SetQuestion("example.com.", dns.TypeANY)
+					o := &net.DNSError{
+						IsTimeout: true,
+					}
+					fakeExchanger.ExchangeReturns(&dns.Msg{}, 0, o)
+				})
+
+				It("server failure response based on i/o timeout", func() {
+					fakeWriter.RemoteAddrReturns(&net.TCPAddr{})
+
+					recursionHandler.ServeDNS(fakeWriter, requestMessage)
+					Expect(fakeTruncater.TruncateIfNeededCallCount()).To(Equal(0))
+					message := fakeWriter.WriteMsgArgsForCall(0)
+					Expect(message.Rcode).To(Equal(dns.RcodeServerFailure))
+				})
+			})
+
+			Context("i/o timeout with retry", func() {
+				var (
+					requestMessage *dns.Msg
+					dnsServer1     string
+					dnsServer2     string
+					protocol       string
+					retryCount     int
+					recursors      []string
+					factory        handlers.ExchangerFactory
+				)
+
+				BeforeEach(func() {
+					dnsServer1 = "127.0.0.1:62000"
+					dnsServer2 = "127.0.0.1:62001"
+					protocol = "udp"
+					retryCount = 2
+
+					requestMessage = &dns.Msg{}
+					requestMessage.SetQuestion("example.com.", dns.TypeANY)
+					factory = handlers.NewExchangerFactory(1 * time.Second)
+					recursors = []string{dnsServer1, dnsServer2}
+				})
+
+				It("smart recursors with retry", func() {
+					pool := handlers.NewFailoverRecursorPool(recursors, config.SmartRecursorSelection, retryCount, fakeLogger)
+					recursionHandler = handlers.NewForwardHandler(pool, factory, fakeClock, fakeLogger, fakeTruncater)
+
+					//create a fake dns endpoint that times out because of no response
+					listen, err := net.ListenPacket(protocol, dnsServer1)
+					readBytes1 := make([]byte, 1024)
+					retryCalled := 0
+					if err != nil {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					defer listen.Close()
+					go func() {
+						for {
+							//ignore send information just response
+							listen.ReadFrom(readBytes1)
+							retryCalled++
+						}
+					}()
+
+					fineListener, err := net.ListenPacket(protocol, dnsServer2)
+					readBytes2 := make([]byte, 1024)
+					if err != nil {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					defer fineListener.Close()
+					go func() {
+						for {
+							//ignore send information just response
+							bl, addr, _ := fineListener.ReadFrom(readBytes2)
+							fineListener.WriteTo(readBytes2[:bl], addr)
+
+						}
+					}()
+
+					recursionHandler.ServeDNS(fakeWriter, requestMessage)
+					message := fakeWriter.WriteMsgArgsForCall(0)
+					Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
+					Expect(retryCalled).To(Equal(retryCount))
+				})
+
+				It("serial recursors with retry", func() {
+					pool := handlers.NewFailoverRecursorPool(recursors, config.SerialRecursorSelection, retryCount, fakeLogger)
+					recursionHandler = handlers.NewForwardHandler(pool, factory, fakeClock, fakeLogger, fakeTruncater)
+
+					//create a fake dns endpoint that times out because of no response
+					listen, err := net.ListenPacket(protocol, dnsServer1)
+					readBytes1 := make([]byte, 1024)
+					retryCalled := 0
+					if err != nil {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					defer listen.Close()
+					go func() {
+						for {
+							//ignore send information just response
+							listen.ReadFrom(readBytes1)
+							retryCalled++
+						}
+					}()
+
+					fineListener, err := net.ListenPacket(protocol, dnsServer2)
+					fineListener.SetReadDeadline(time.Time{})
+					readBytes2 := make([]byte, 1024)
+					if err != nil {
+						Expect(err).ToNot(HaveOccurred())
+					}
+
+					defer fineListener.Close()
+					go func() {
+						for {
+							//ignore send information just response
+							bl, addr, _ := fineListener.ReadFrom(readBytes2)
+							fineListener.WriteTo(readBytes2[:bl], addr)
+						}
+					}()
+
+					recursionHandler.ServeDNS(fakeWriter, requestMessage)
+					message := fakeWriter.WriteMsgArgsForCall(0)
+					Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
+					Expect(retryCalled).To(Equal(retryCount))
+				})
+			})
 
 			Context("truncation", func() {
 				var (

--- a/src/bosh-dns/dns/server/handlers/forward_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler_test.go
@@ -276,7 +276,7 @@ var _ = Describe("ForwardHandler", func() {
 					dnsServer1     string
 					dnsServer2     string
 					protocol       string
-					retryCount     int
+					maxRetries     int
 					initialCall    int
 					recursors      []string
 					factory        handlers.ExchangerFactory
@@ -286,7 +286,7 @@ var _ = Describe("ForwardHandler", func() {
 					dnsServer1 = "127.0.0.1:62000"
 					dnsServer2 = "127.0.0.1:62001"
 					protocol = "udp"
-					retryCount = 2
+					maxRetries = 2
 					initialCall = 1
 
 					requestMessage = &dns.Msg{}
@@ -296,7 +296,7 @@ var _ = Describe("ForwardHandler", func() {
 				})
 
 				It("smart recursors with retry", func() {
-					pool := handlers.NewFailoverRecursorPool(recursors, config.SmartRecursorSelection, retryCount, fakeLogger)
+					pool := handlers.NewFailoverRecursorPool(recursors, config.SmartRecursorSelection, maxRetries, fakeLogger)
 					recursionHandler = handlers.NewForwardHandler(pool, factory, fakeClock, fakeLogger, fakeTruncater)
 
 					//create a fake dns endpoint that times out because of no response
@@ -335,11 +335,11 @@ var _ = Describe("ForwardHandler", func() {
 					recursionHandler.ServeDNS(fakeWriter, requestMessage)
 					message := fakeWriter.WriteMsgArgsForCall(0)
 					Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
-					Expect(retryCalled).To(Equal(retryCount + initialCall))
+					Expect(retryCalled).To(Equal(maxRetries + initialCall))
 				})
 
 				It("serial recursors with retry", func() {
-					pool := handlers.NewFailoverRecursorPool(recursors, config.SerialRecursorSelection, retryCount, fakeLogger)
+					pool := handlers.NewFailoverRecursorPool(recursors, config.SerialRecursorSelection, maxRetries, fakeLogger)
 					recursionHandler = handlers.NewForwardHandler(pool, factory, fakeClock, fakeLogger, fakeTruncater)
 
 					//create a fake dns endpoint that times out because of no response
@@ -378,7 +378,7 @@ var _ = Describe("ForwardHandler", func() {
 					recursionHandler.ServeDNS(fakeWriter, requestMessage)
 					message := fakeWriter.WriteMsgArgsForCall(0)
 					Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
-					Expect(retryCalled).To(Equal(retryCount + initialCall))
+					Expect(retryCalled).To(Equal(maxRetries + initialCall))
 				})
 			})
 

--- a/src/bosh-dns/dns/server/handlers/forward_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler_test.go
@@ -131,7 +131,7 @@ var _ = Describe("ForwardHandler", func() {
 				recursionHandler.ServeDNS(fakeWriter, msg)
 				Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
 
-				Expect(fakeLogger.ErrorCallCount()).To(Equal(2))
+				Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
 				Expect(fakeLogger.DebugCallCount()).To(Equal(2))
 				tag, logMsg, args := fakeLogger.ErrorArgsForCall(0)
 				Expect(tag).To(Equal("ForwardHandler"))
@@ -162,7 +162,7 @@ var _ = Describe("ForwardHandler", func() {
 
 					recursionHandler.ServeDNS(fakeWriter, msg)
 
-					Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
+					Expect(fakeLogger.ErrorCallCount()).To(Equal(4))
 					tag, msg, args := fakeLogger.ErrorArgsForCall(2)
 					Expect(tag).To(Equal("ForwardHandler"))
 					Expect(fmt.Sprintf(msg, args...)).To(Equal("error writing response: failed to write message"))
@@ -277,6 +277,7 @@ var _ = Describe("ForwardHandler", func() {
 					dnsServer2     string
 					protocol       string
 					retryCount     int
+					initialCall    int
 					recursors      []string
 					factory        handlers.ExchangerFactory
 				)
@@ -286,6 +287,7 @@ var _ = Describe("ForwardHandler", func() {
 					dnsServer2 = "127.0.0.1:62001"
 					protocol = "udp"
 					retryCount = 2
+					initialCall = 1
 
 					requestMessage = &dns.Msg{}
 					requestMessage.SetQuestion("example.com.", dns.TypeANY)
@@ -333,7 +335,7 @@ var _ = Describe("ForwardHandler", func() {
 					recursionHandler.ServeDNS(fakeWriter, requestMessage)
 					message := fakeWriter.WriteMsgArgsForCall(0)
 					Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
-					Expect(retryCalled).To(Equal(retryCount))
+					Expect(retryCalled).To(Equal(retryCount + initialCall))
 				})
 
 				It("serial recursors with retry", func() {
@@ -376,7 +378,7 @@ var _ = Describe("ForwardHandler", func() {
 					recursionHandler.ServeDNS(fakeWriter, requestMessage)
 					message := fakeWriter.WriteMsgArgsForCall(0)
 					Expect(message.Rcode).To(Equal(dns.RcodeSuccess))
-					Expect(retryCalled).To(Equal(retryCount))
+					Expect(retryCalled).To(Equal(retryCount + initialCall))
 				})
 			})
 
@@ -426,7 +428,7 @@ var _ = Describe("ForwardHandler", func() {
 
 				It("writes a failure result", func() {
 					Expect(fakeLogger.DebugCallCount()).To(Equal(2))
-					Expect(fakeLogger.ErrorCallCount()).To(Equal(2))
+					Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
 					tag, msg, args := fakeLogger.ErrorArgsForCall(0)
 					Expect(tag).To(Equal("ForwardHandler"))
 					Expect(fmt.Sprintf(msg, args...)).To(Equal(`error recursing for example.com. to "127.0.0.1": failed to exchange`))

--- a/src/bosh-dns/dns/server/handlers/forward_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler_test.go
@@ -131,7 +131,7 @@ var _ = Describe("ForwardHandler", func() {
 				recursionHandler.ServeDNS(fakeWriter, msg)
 				Expect(fakeWriter.WriteMsgCallCount()).To(Equal(1))
 
-				Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
+				Expect(fakeLogger.ErrorCallCount()).To(Equal(2))
 				Expect(fakeLogger.DebugCallCount()).To(Equal(2))
 				tag, logMsg, args := fakeLogger.ErrorArgsForCall(0)
 				Expect(tag).To(Equal("ForwardHandler"))
@@ -162,7 +162,7 @@ var _ = Describe("ForwardHandler", func() {
 
 					recursionHandler.ServeDNS(fakeWriter, msg)
 
-					Expect(fakeLogger.ErrorCallCount()).To(Equal(4))
+					Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
 					tag, msg, args := fakeLogger.ErrorArgsForCall(2)
 					Expect(tag).To(Equal("ForwardHandler"))
 					Expect(fmt.Sprintf(msg, args...)).To(Equal("error writing response: failed to write message"))
@@ -428,7 +428,7 @@ var _ = Describe("ForwardHandler", func() {
 
 				It("writes a failure result", func() {
 					Expect(fakeLogger.DebugCallCount()).To(Equal(2))
-					Expect(fakeLogger.ErrorCallCount()).To(Equal(3))
+					Expect(fakeLogger.ErrorCallCount()).To(Equal(2))
 					tag, msg, args := fakeLogger.ErrorArgsForCall(0)
 					Expect(tag).To(Equal("ForwardHandler"))
 					Expect(fmt.Sprintf(msg, args...)).To(Equal(`error recursing for example.com. to "127.0.0.1": failed to exchange`))


### PR DESCRIPTION
Hi all,

I just implemented the retry mechanism for the `ServeDNS` requests.
The matching issue for that pr was #74
The issue was that it could happen that the  [`client.Exchange`](https://github.com/HappyTobi/bosh-dns-release/blob/0c0df677751e33b6dc21ba1df4c1e70f28bab2d5/src/bosh-dns/dns/server/handlers/forward_handler.go#L62) call gets en error because of an timeout or any other related network issue. 

So with the new implementation it's possible to setup and configure a `retry_count` with the new `recursor_retry_count` property at the bosh-dns configuration.
With that `retry` a failed response will be triggered again till the counter was reached. 

@mrosecrance
What do you think about the implementation? Can you give me some feedback?


I've also tested the new bosh-dns build on a running instance and the log of the fix will look like:
```
[FailoverRecursor] 2021-01-28T17:26:48.296952065Z DEBUG - dns request error received NXDOMAIN for foo.bar.xyz. from upstream (recursor: XXX.XX.XXX.XX:53) no retry - XXX.XX.XXX.XX:53
```

and for a network / i/o timeout:
```
[ForwardHandler] 2021-01-28T17:26:541327202Z ERROR - error recursing for tacoda.net. to "XXX.XX.XXX.XX:53": read udp XX.X.X.X:47601->XXX.XX.XXX.XX: i/o timeout
[FailoverRecursor] 2021-01-28T17:26:541327202Z ERROR - dns request network error read udp XX.X.X.X:47601->XXX.XX.XXX.XX:53: i/o timeout retry [1/3] for recoursor XXX.XX.XXX.XX53
[ForwardHandler] 2021-01-28T17:26:53.541652001Z ERROR - error recursing for tacoda.net. to "XXX.XX.XXX.XX:53": read udp XX.X.X.X:47601->XXX.XX.XXX.XX: i/o timeout
[FailoverRecursor] 2021-01-28T17:26:53.541687501Z ERROR - dns request network error read udp XX.X.X.X:47601->XXX.XX.XXX.XX:53: i/o timeout retry [2/3] for recoursor XXX.XX.XXX.XX53
[ForwardHandler] 2021-01-28T17:26:542092900Z ERROR - error recursing for tacoda.net. to "XXX.XX.XXX.XX:53": read udp XX.X.X.X:47601->XXX.XX.XXX.XX: i/o timeout
[FailoverRecursor] 2021-01-28T17:26:542092900Z ERROR - dns request network error read udp XX.X.X.X:47601->XXX.XX.XXX.XX:53: i/o timeout retry [3/3] for recoursor XXX.XX.XXX.XX53
```
