### PR TITLE
Adding a dedicated recursion logging

### DIFF
--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -48,6 +48,9 @@ properties:
   log_level:
     description: Logging level (DEBUG, INFO, WARN, ERROR, NONE)
     default: INFO
+  enable_recursion_logging:
+    description: Enable dedicated recursion logging to stdout
+    default: false
 
   api.port:
     description: "Port that the DNS servers debug API will listen on"

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -3,6 +3,7 @@
   address: p('address'),
   port: p('port'),
   log_level: p('log_level'),
+  enable_recursion_logging: p('enable_recursion_logging'),
   recursors: p('recursors'),
   excluded_recursors: p('excluded_recursors'),
   records_file: p('records_file'),

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -35,7 +35,8 @@ type Config struct {
 	UpcheckDomains     []string     `json:"upcheck_domains,omitempty"`
 	JobsDir            string       `json:"jobs_dir,omitempty"`
 
-	LogLevel string `json:"log_level,omitempty"`
+	LogLevel               string   `json:"log_level,omitempty"`
+	EnableRecursionLogging bool     `json:"enable_recursion_logging"`
 
 	API APIConfig `json:"api"`
 


### PR DESCRIPTION
This feature allows recursion logging to stdout on INFO level.
Currently this is only possible using `DEBUG` level which is not an option in production.

Using `DEBUG` level in production might overload the logging platform with too many messages. We need recursion messages to analyze our dns traffic, this approach is to reduce the number of log messages.

As a followup we need to filter this with a positive list of domains, but first we try to filter the messages on our logging platform. 


Co-authored-by: Matthias Vach