### PR TITLE
Fix: `go vet` errors

### DIFF
--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -92,7 +92,7 @@ type InternalUpcheckDomain struct {
 }
 
 type LoggingConfig struct {
-	Format FormatConfig `json"format,omitempty"`
+	Format FormatConfig `json:"format,omitempty"`
 }
 
 type FormatConfig struct {

--- a/src/bosh-dns/healthcheck/healthserver/health_server.go
+++ b/src/bosh-dns/healthcheck/healthserver/health_server.go
@@ -67,7 +67,8 @@ func (c *concreteHealthServer) Serve(config *healthconfig.HealthCheckConfig) {
 	go func() {
 		<-c.shutdown
 		server.SetKeepAlivesEnabled(false)
-		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
 		err = server.Shutdown(ctx)
 		if err != nil {
 			c.logger.Error(logTag, "http healthcheck error during shutdown %s", err)

--- a/src/bosh-dns/performance_tests/init_test.go
+++ b/src/bosh-dns/performance_tests/init_test.go
@@ -2,7 +2,7 @@ package performance_test
 
 import (
 	"bosh-dns/dns/config"
-	"bosh-dns/healthcheck/healthserver"
+	"bosh-dns/healthconfig"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -124,7 +124,7 @@ func startHealthServer(addr string) {
 	healthFile, err := ioutil.TempFile("", "health.json")
 	Expect(err).ToNot(HaveOccurred())
 
-	healthConfigContents, err := json.Marshal(healthserver.HealthCheckConfig{
+	healthConfigContents, err := json.Marshal(healthconfig.HealthCheckConfig{
 		Address:                  addr,
 		Port:                     healthPort,
 		CertificateFile:          "../healthcheck/assets/test_certs/test_server.pem",

--- a/src/bosh-dns/wait/main.go
+++ b/src/bosh-dns/wait/main.go
@@ -35,7 +35,8 @@ func main() {
 
 	go func() {
 		for {
-			tc, _ := context.WithTimeout(context.Background(), time.Second)
+			tc, cancel := context.WithTimeout(context.Background(), time.Second)
+			defer cancel()
 			hosts, err := resolver.LookupHost(tc, *domain)
 			if err == nil {
 				log.Debug("wait", "%+v", hosts)


### PR DESCRIPTION
* Fix json struct tag format (it was missing a colon).
* Call cancel functions when generating a context that has them.
* HealthCheckConfig appears to have moved packages at some point,
  correcting that.