### PR TITLE
Reformat go files with `goimports`

### DIFF
--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/main.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/main.go
@@ -193,7 +193,7 @@ func main() {
 		}
 		msg.Answer = append(msg.Answer, aRec)
 
-		if msg.Id % 2 == 1 {
+		if msg.Id%2 == 1 {
 			time.Sleep(2 * time.Second)
 		}
 		err := resp.WriteMsg(msg)
@@ -208,7 +208,7 @@ func main() {
 		msg.Authoritative = true
 		msg.RecursionAvailable = true
 
-		if msg.Id % 2 == 1 {
+		if msg.Id%2 == 1 {
 			msg.SetRcode(req, dns.RcodeNameError)
 		} else {
 			msg.SetRcode(req, dns.RcodeSuccess)

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/fuzz.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/fuzz.go
@@ -1,3 +1,4 @@
+//go:build fuzz
 // +build fuzz
 
 package dns

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/listen_no_reuseport.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/listen_no_reuseport.go
@@ -1,3 +1,4 @@
+//go:build !go1.11 || (!aix && !darwin && !dragonfly && !freebsd && !linux && !netbsd && !openbsd)
 // +build !go1.11 !aix,!darwin,!dragonfly,!freebsd,!linux,!netbsd,!openbsd
 
 package dns

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/listen_reuseport.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/listen_reuseport.go
@@ -1,3 +1,4 @@
+//go:build go1.11 && (aix || darwin || dragonfly || freebsd || linux || netbsd || openbsd)
 // +build go1.11
 // +build aix darwin dragonfly freebsd linux netbsd openbsd
 

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/singleinflight.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/singleinflight.go
@@ -6,8 +6,10 @@
 
 package dns
 
-import "sync"
-import "time"
+import (
+	"sync"
+	"time"
+)
 
 // call is an in-flight or completed singleflight.Do call
 type call struct {

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/tools.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 // We include our tool dependencies for `go generate` here to ensure they're

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/udp.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/udp.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package dns

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/udp_windows.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/github.com/miekg/dns/udp_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package dns

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/golang.org/x/tools/go/packages/external.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/golang.org/x/tools/go/packages/external.go
@@ -12,9 +12,10 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	exec "golang.org/x/sys/execabs"
 	"os"
 	"strings"
+
+	exec "golang.org/x/sys/execabs"
 )
 
 // The Driver Protocol

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/gopkg.in/yaml.v2/readerc.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/gopkg.in/yaml.v2/readerc.go
@@ -95,7 +95,7 @@ func yaml_parser_update_buffer(parser *yaml_parser_t, length int) bool {
 
 	// [Go] This function was changed to guarantee the requested length size at EOF.
 	// The fact we need to do this is pretty awful, but the description above implies
-	// for that to be the case, and there are tests 
+	// for that to be the case, and there are tests
 
 	// If the EOF flag is set and the raw buffer is empty, do nothing.
 	if parser.eof && parser.raw_buffer_pos == len(parser.raw_buffer) {

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/gopkg.in/yaml.v2/resolve.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/gopkg.in/yaml.v2/resolve.go
@@ -180,7 +180,7 @@ func resolve(tag string, in string) (rtag string, out interface{}) {
 					return yaml_INT_TAG, uintv
 				}
 			} else if strings.HasPrefix(plain, "-0b") {
-				intv, err := strconv.ParseInt("-" + plain[3:], 2, 64)
+				intv, err := strconv.ParseInt("-"+plain[3:], 2, 64)
 				if err == nil {
 					if true || intv == int64(int(intv)) {
 						return yaml_INT_TAG, int(intv)

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/gopkg.in/yaml.v2/sorter.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/vendor/gopkg.in/yaml.v2/sorter.go
@@ -52,7 +52,7 @@ func (l keyList) Less(i, j int) bool {
 		var ai, bi int
 		var an, bn int64
 		if ar[i] == '0' || br[i] == '0' {
-			for j := i-1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
+			for j := i - 1; j >= 0 && unicode.IsDigit(ar[j]); j-- {
 				if ar[j] != '0' {
 					an = 1
 					bn = 1

--- a/src/bosh-dns/acceptance_tests/linux/init_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/init_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package linux_test

--- a/src/bosh-dns/acceptance_tests/linux/linux_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/linux_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package linux_test

--- a/src/bosh-dns/acceptance_tests/linux/override_nameserver/disabled/disabled_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/override_nameserver/disabled/disabled_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package override_nameserver

--- a/src/bosh-dns/acceptance_tests/linux/override_nameserver/disabled/suite_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/override_nameserver/disabled/suite_test.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin
 // +build linux darwin
 
 package override_nameserver

--- a/src/bosh-dns/acceptance_tests/support_test.go
+++ b/src/bosh-dns/acceptance_tests/support_test.go
@@ -167,7 +167,7 @@ func setupSecureGet() *httpclient.HTTPClient {
 	Expect(err).NotTo(HaveOccurred())
 
 	logger := logger.NewAsyncWriterLogger(logger.LevelDebug, ioutil.Discard)
-	client, err := tlsclient.New("health.bosh-dns", []byte(caCert), cert, 5 * time.Second, logger)
+	client, err := tlsclient.New("health.bosh-dns", []byte(caCert), cert, 5*time.Second, logger)
 	Expect(err).NotTo(HaveOccurred())
 	return client
 }

--- a/src/bosh-dns/acceptance_tests/windows/disable_nameserver_override/disabled_test.go
+++ b/src/bosh-dns/acceptance_tests/windows/disable_nameserver_override/disabled_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package disable_nameserver_override_test

--- a/src/bosh-dns/acceptance_tests/windows/disable_nameserver_override/init_test.go
+++ b/src/bosh-dns/acceptance_tests/windows/disable_nameserver_override/init_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package disable_nameserver_override_test

--- a/src/bosh-dns/acceptance_tests/windows/init_test.go
+++ b/src/bosh-dns/acceptance_tests/windows/init_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windows_test

--- a/src/bosh-dns/acceptance_tests/windows/windows_test.go
+++ b/src/bosh-dns/acceptance_tests/windows/windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package windows_test

--- a/src/bosh-dns/dns/helper_unix.go
+++ b/src/bosh-dns/dns/helper_unix.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package main
 

--- a/src/bosh-dns/dns/internal/datatests/sanitize.go
+++ b/src/bosh-dns/dns/internal/datatests/sanitize.go
@@ -7,7 +7,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/nu7hatch/gouuid"
+	uuid "github.com/nu7hatch/gouuid"
 )
 
 var valueSanitizer = valueSanitizer_{}

--- a/src/bosh-dns/dns/main_test.go
+++ b/src/bosh-dns/dns/main_test.go
@@ -1148,7 +1148,7 @@ var _ = Describe("main", func() {
 						}
 
 						return response.Answer[0].(*dns.A).A.String()
-					}, 5 * time.Second).Should(Equal("127.0.0.3"))
+					}, 5*time.Second).Should(Equal("127.0.0.3"))
 				})
 			})
 

--- a/src/bosh-dns/dns/manager/syscall_windows.go
+++ b/src/bosh-dns/dns/manager/syscall_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package manager

--- a/src/bosh-dns/dns/nameserverconfig/helper_unix.go
+++ b/src/bosh-dns/dns/nameserverconfig/helper_unix.go
@@ -1,9 +1,11 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package main
 
 import (
 	"bosh-dns/dns/manager"
+
 	"code.cloudfoundry.org/clock"
 	"github.com/cloudfoundry/bosh-utils/logger"
 	boshsys "github.com/cloudfoundry/bosh-utils/system"

--- a/src/bosh-dns/dns/nameserverconfig/main.go
+++ b/src/bosh-dns/dns/nameserverconfig/main.go
@@ -28,9 +28,9 @@ func main() {
 	}
 
 	logger := boshlog.NewAsyncWriterLogger(boshlog.LevelDebug, os.Stdout)
-    if logFormat == "rfc3339" {
-        logger.UseRFC3339Timestamps()
-    }
+	if logFormat == "rfc3339" {
+		logger.UseRFC3339Timestamps()
+	}
 	defer logger.FlushTimeout(5 * time.Second)
 
 	shutdown := make(chan struct{})

--- a/src/bosh-dns/dns/server/aliases/config.go
+++ b/src/bosh-dns/dns/server/aliases/config.go
@@ -133,19 +133,18 @@ func (c Config) Resolutions(maybeAlias string) []string {
 }
 
 func (c Config) AliasResolutions(domain string) []string {
-   var exactMatchAliases []string
-    for alias, domains := range c.aliases {
-        for _, aliasDomain := range domains {
+	var exactMatchAliases []string
+	for alias, domains := range c.aliases {
+		for _, aliasDomain := range domains {
 			if aliasDomain == domain {
-                  exactMatchAliases = append(exactMatchAliases, alias)
-                  break
-           }
-        }
-    }
+				exactMatchAliases = append(exactMatchAliases, alias)
+				break
+			}
+		}
+	}
 
-    return exactMatchAliases
+	return exactMatchAliases
 }
-
 
 func (c Config) Merge(other Config) Config {
 	for alias, targets := range other.aliases {

--- a/src/bosh-dns/dns/server/aliases/config_test.go
+++ b/src/bosh-dns/dns/server/aliases/config_test.go
@@ -179,7 +179,7 @@ var _ = Describe("Config", func() {
 	Describe("AliasResolutions", func() {
 		It("resolves a FQDNs to the aliases that match", func() {
 			c := MustNewConfigFromMap(map[string][]string{
-				"something.alias":    {"domain"},
+				"something.alias": {"domain"},
 			})
 
 			Expect(c.AliasResolutions("domain.")).To(Equal([]string{"something.alias."}))
@@ -187,7 +187,7 @@ var _ = Describe("Config", func() {
 
 		It("resolves an ip to aliases that match", func() {
 			c := MustNewConfigFromMap(map[string][]string{
-				"something.alias":    {"1.1.1.1"},
+				"something.alias": {"1.1.1.1"},
 			})
 
 			Expect(c.AliasResolutions("1.1.1.1")).To(Equal([]string{"something.alias."}))
@@ -196,7 +196,7 @@ var _ = Describe("Config", func() {
 		It("does not resolve underscored or wildcard domains", func() {
 			c := MustNewConfigFromMap(map[string][]string{
 				"alias-wildcard":     {"*.domain"},
-				"query-alias":     {"q-s0.domain"},
+				"query-alias":        {"q-s0.domain"},
 				"_.alias-underscore": {"_.domain"},
 			})
 

--- a/src/bosh-dns/dns/server/handlers/exchanger_factory_test.go
+++ b/src/bosh-dns/dns/server/handlers/exchanger_factory_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"bosh-dns/dns/server/handlers"
+
 	"github.com/miekg/dns"
 )
 

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
@@ -4,9 +4,10 @@ import (
 	"bosh-dns/dns/config"
 	"errors"
 	"fmt"
-	"github.com/miekg/dns"
 	"net"
 	"sync/atomic"
+
+	"github.com/miekg/dns"
 
 	"github.com/cloudfoundry/bosh-utils/logger"
 )

--- a/src/bosh-dns/dns/server/handlers/internal/log_request.go
+++ b/src/bosh-dns/dns/server/handlers/internal/log_request.go
@@ -2,9 +2,10 @@ package internal
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/cloudfoundry/bosh-utils/logger"
 	"github.com/miekg/dns"
-	"strings"
 )
 
 func LogRequest(logger logger.Logger, handler dns.Handler, logTag string, duration int64, request *dns.Msg, response *dns.Msg, customMessage string) {

--- a/src/bosh-dns/dns/server/handlers/internal/log_request_test.go
+++ b/src/bosh-dns/dns/server/handlers/internal/log_request_test.go
@@ -3,10 +3,11 @@ package internal_test
 import (
 	"bosh-dns/dns/server/handlers"
 	"bosh-dns/dns/server/handlers/internal"
-	"code.cloudfoundry.org/clock/fakeclock"
 	"fmt"
-	"github.com/miekg/dns"
 	"net"
+
+	"code.cloudfoundry.org/clock/fakeclock"
+	"github.com/miekg/dns"
 
 	"time"
 
@@ -17,11 +18,11 @@ import (
 
 var _ = Describe("RequestLoggerHandler", func() {
 	var (
-		fakeLogger *loggerfakes.FakeLogger
-		handler    handlers.RequestLoggerHandler
-		child      dns.Handler
-		fakeClock  *fakeclock.FakeClock
-		dnsRequest *dns.Msg
+		fakeLogger  *loggerfakes.FakeLogger
+		handler     handlers.RequestLoggerHandler
+		child       dns.Handler
+		fakeClock   *fakeclock.FakeClock
+		dnsRequest  *dns.Msg
 		dnsResponse *dns.Msg
 
 		makeHandler func() dns.Handler

--- a/src/bosh-dns/dns/server/handlers/metrics_handler.go
+++ b/src/bosh-dns/dns/server/handlers/metrics_handler.go
@@ -14,7 +14,7 @@ type MetricsDNSHandler struct {
 func NewMetricsDNSHandler(metricsReporter monitoring.MetricsReporter, requestType monitoring.DNSRequestType) MetricsDNSHandler {
 	return MetricsDNSHandler{
 		metricsReporter: metricsReporter,
-		requestType: requestType,
+		requestType:     requestType,
 	}
 }
 

--- a/src/bosh-dns/dns/server/handlers/metrics_handler_test.go
+++ b/src/bosh-dns/dns/server/handlers/metrics_handler_test.go
@@ -2,9 +2,10 @@ package handlers_test
 
 import (
 	"bosh-dns/dns/server/handlers"
-	"bosh-dns/dns/server/monitoring"
 	"bosh-dns/dns/server/handlers/handlersfakes"
 	"bosh-dns/dns/server/internal/internalfakes"
+	"bosh-dns/dns/server/monitoring"
+
 	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
 
 	"github.com/miekg/dns"
@@ -14,9 +15,9 @@ import (
 
 var _ bool = Describe("metricsHandler", func() {
 	var (
-		metricsHandler      handlers.MetricsDNSHandler
-		metricsReporter     monitoring.MetricsReporter
-		metricsServer       monitoring.CoreDNSMetricsServer
+		metricsHandler  handlers.MetricsDNSHandler
+		metricsReporter monitoring.MetricsReporter
+		metricsServer   monitoring.CoreDNSMetricsServer
 
 		fakeWriter             *internalfakes.FakeResponseWriter
 		fakeDnsHandlerInternal *handlersfakes.FakeDNSHandler

--- a/src/bosh-dns/dns/server/handlers/request_logger_handler.go
+++ b/src/bosh-dns/dns/server/handlers/request_logger_handler.go
@@ -2,6 +2,7 @@ package handlers
 
 import (
 	"bosh-dns/dns/server/handlers/internal"
+
 	"code.cloudfoundry.org/clock"
 
 	"github.com/cloudfoundry/bosh-utils/logger"
@@ -28,7 +29,7 @@ func (h RequestLoggerHandler) ServeDNS(responseWriter dns.ResponseWriter, req *d
 	internal.LogReceivedRequest(h.logger, h.Handler, h.logTag, req)
 	var dnsMsg *dns.Msg
 	respWriter := internal.WrapWriterWithIntercept(responseWriter, func(msg *dns.Msg) {
-		dnsMsg=msg
+		dnsMsg = msg
 	})
 
 	before := h.clock.Now()

--- a/src/bosh-dns/dns/server/healthiness/health_checker_test.go
+++ b/src/bosh-dns/dns/server/healthiness/health_checker_test.go
@@ -4,8 +4,9 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
 	"io/ioutil"
+
+	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
 
 	"bosh-dns/dns/server/healthiness"
 	"bosh-dns/dns/server/healthiness/healthinessfakes"

--- a/src/bosh-dns/dns/server/monitoring/dns_request_type.go
+++ b/src/bosh-dns/dns/server/monitoring/dns_request_type.go
@@ -3,6 +3,7 @@ package monitoring
 import (
 	"context"
 	"errors"
+
 	"github.com/miekg/dns"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
@@ -12,7 +13,7 @@ import (
 type DNSRequestType string
 type key int
 
-const(
+const (
 	// DNSRequestTypeInternal is used for internal dns requests
 	DNSRequestTypeInternal DNSRequestType = "internal"
 	// DNSRequestTypeExternal is used for external dns requests
@@ -34,10 +35,10 @@ func NewPluginHandlerAdapter(internalHandler dns.Handler, externalHandler dns.Ha
 type pluginHandlerAdapter struct {
 	internalHandler dns.Handler
 	externalHandler dns.Handler
-	requestManager RequestCounter
+	requestManager  RequestCounter
 }
 
-func(p pluginHandlerAdapter) Name() string {
+func (p pluginHandlerAdapter) Name() string {
 	return "pluginHandlerAdapter"
 }
 
@@ -69,15 +70,15 @@ func NewRequestManager() RequestManager {
 	return RequestManager{externalRequestsCounter: extReqs, internalRequestsCounter: intReqs}
 }
 
-func(m RequestManager) IncrementExternalCounter() {
+func (m RequestManager) IncrementExternalCounter() {
 	m.externalRequestsCounter.Inc()
 }
 
-func(m RequestManager) IncrementInternalCounter() {
+func (m RequestManager) IncrementInternalCounter() {
 	m.internalRequestsCounter.Inc()
 }
 
-func(p pluginHandlerAdapter) ServeDNS(ctx context.Context, writer dns.ResponseWriter, m *dns.Msg) (int, error) {
+func (p pluginHandlerAdapter) ServeDNS(ctx context.Context, writer dns.ResponseWriter, m *dns.Msg) (int, error) {
 	v := ctx.Value(dnsRequestContext)
 
 	if v == nil {
@@ -93,4 +94,3 @@ func(p pluginHandlerAdapter) ServeDNS(ctx context.Context, writer dns.ResponseWr
 	}
 	return 0, nil
 }
-

--- a/src/bosh-dns/dns/server/monitoring/dns_request_type_test.go
+++ b/src/bosh-dns/dns/server/monitoring/dns_request_type_test.go
@@ -3,8 +3,8 @@ package monitoring_test
 import (
 	"bosh-dns/dns/server/handlers/handlersfakes"
 	"bosh-dns/dns/server/internal/internalfakes"
-	"bosh-dns/dns/server/monitoring/monitoringfakes"
 	"bosh-dns/dns/server/monitoring"
+	"bosh-dns/dns/server/monitoring/monitoringfakes"
 
 	"context"
 
@@ -17,7 +17,7 @@ var _ = Describe("DNSRequestType", func() {
 	var (
 		fakeInternalDnsHandler handlersfakes.FakeDNSHandler
 		fakeExternalDnsHandler handlersfakes.FakeDNSHandler
-		fakeReqCounter monitoringfakes.FakeRequestCounter
+		fakeReqCounter         monitoringfakes.FakeRequestCounter
 
 		fakeWriter internalfakes.FakeResponseWriter
 		request    dns.Msg

--- a/src/bosh-dns/dns/server/monitoring/metrics_server_test.go
+++ b/src/bosh-dns/dns/server/monitoring/metrics_server_test.go
@@ -64,8 +64,8 @@ var _ = Describe("MetricsServerWrapper", func() {
 	Describe("Report", func() {
 		var (
 			metricsReporter monitoring.MetricsReporter
-			metricsServer    monitoring.CoreDNSMetricsServer
-			fakeWriter       *internalfakes.FakeResponseWriter
+			metricsServer   monitoring.CoreDNSMetricsServer
+			fakeWriter      *internalfakes.FakeResponseWriter
 		)
 
 		BeforeEach(func() {

--- a/src/bosh-dns/dns/server/records/dnsresolver/truncater.go
+++ b/src/bosh-dns/dns/server/records/dnsresolver/truncater.go
@@ -1,8 +1,9 @@
 package dnsresolver
 
 import (
-	"github.com/miekg/dns"
 	"net"
+
+	"github.com/miekg/dns"
 )
 
 //go:generate counterfeiter . ResponseTruncater

--- a/src/bosh-dns/dns/server/records/filterer_factory.go
+++ b/src/bosh-dns/dns/server/records/filterer_factory.go
@@ -22,7 +22,7 @@ type FiltererFactory interface {
 }
 
 type healthFiltererFactory struct {
-	healthWatcher healthiness.HealthWatcher
+	healthWatcher           healthiness.HealthWatcher
 	synchronousCheckTimeout time.Duration
 }
 
@@ -37,7 +37,7 @@ func (hff *healthFiltererFactory) NewQueryFilterer() Filterer {
 
 func NewHealthFiltererFactory(healthWatcher healthiness.HealthWatcher, synchronousCheckTimeout time.Duration) FiltererFactory {
 	return &healthFiltererFactory{
-		healthWatcher: healthWatcher,
+		healthWatcher:           healthWatcher,
 		synchronousCheckTimeout: synchronousCheckTimeout,
 	}
 }

--- a/src/bosh-dns/dns/server/records/health_filter.go
+++ b/src/bosh-dns/dns/server/records/health_filter.go
@@ -15,14 +15,14 @@ import (
 )
 
 type healthFilter struct {
-	nextFilter     Reducer
-	health         chan<- record.Host
-	w              healthWatcher
-	wg             *sync.WaitGroup
-	shouldTrack    bool
-	domain         string
-	filterWorkPool *workpool.WorkPool
-	clock          clock.Clock
+	nextFilter              Reducer
+	health                  chan<- record.Host
+	w                       healthWatcher
+	wg                      *sync.WaitGroup
+	shouldTrack             bool
+	domain                  string
+	filterWorkPool          *workpool.WorkPool
+	clock                   clock.Clock
 	synchronousCheckTimeout time.Duration
 }
 
@@ -39,13 +39,13 @@ type healthWatcher interface {
 func NewHealthFilter(nextFilter Reducer, health chan<- record.Host, w healthWatcher, shouldTrack bool, clock clock.Clock, synchronousCheckTimeout time.Duration, wg *sync.WaitGroup) healthFilter {
 	wp, _ := workpool.NewWorkPool(1000)
 	return healthFilter{
-		nextFilter:     nextFilter,
-		health:         health,
-		w:              w,
-		wg:             wg,
-		shouldTrack:    shouldTrack,
-		filterWorkPool: wp,
-		clock:          clock,
+		nextFilter:              nextFilter,
+		health:                  health,
+		w:                       w,
+		wg:                      wg,
+		shouldTrack:             shouldTrack,
+		filterWorkPool:          wp,
+		clock:                   clock,
 		synchronousCheckTimeout: synchronousCheckTimeout,
 	}
 }

--- a/src/bosh-dns/dns/server/server.go
+++ b/src/bosh-dns/dns/server/server.go
@@ -137,7 +137,7 @@ func (s Server) shutdown() error {
 
 	for _, server := range s.servers {
 		go func(server DNSServer) {
-			shutdownContext, cancel := context.WithTimeout(context.Background(), 5 * time.Second)
+			shutdownContext, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 			defer cancel()
 			err <- server.ShutdownContext(shutdownContext)
 			wg.Done()

--- a/src/bosh-dns/dns/server/server_test.go
+++ b/src/bosh-dns/dns/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"bosh-dns/dns/server/serverfakes"
 
 	"bosh-dns/dns/internal/testhelpers"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 )
@@ -144,9 +145,9 @@ var _ = Describe("Server", func() {
 		udpUpcheck = upCheck()
 
 		SetDefaultEventuallyTimeout(timeout + 2*time.Second)
-		SetDefaultEventuallyPollingInterval(500*time.Millisecond)
+		SetDefaultEventuallyPollingInterval(500 * time.Millisecond)
 		SetDefaultConsistentlyDuration(timeout + 2*time.Second)
-		SetDefaultConsistentlyPollingInterval(500*time.Millisecond)
+		SetDefaultConsistentlyPollingInterval(500 * time.Millisecond)
 
 		pollingInterval = 5 * time.Second
 	})

--- a/src/bosh-dns/dns/server/tracker/tracker.go
+++ b/src/bosh-dns/dns/server/tracker/tracker.go
@@ -3,8 +3,9 @@ package tracker
 import (
 	"bosh-dns/dns/server/criteria"
 	"bosh-dns/dns/server/record"
-	"github.com/cloudfoundry/bosh-utils/logger"
 	"sync"
+
+	"github.com/cloudfoundry/bosh-utils/logger"
 )
 
 type Tracker struct {
@@ -13,7 +14,7 @@ type Tracker struct {
 	trackedIPs      map[string]map[string]struct{}
 	trackedIPsMutex *sync.Mutex
 	qf              query
-	logger logger.Logger
+	logger          logger.Logger
 }
 
 //go:generate counterfeiter -o ./fakes/limited_transcript.go --fake-name LimitedTranscript . limitedTranscript
@@ -40,7 +41,7 @@ func Start(shutdown chan struct{}, subscription <-chan []record.Record, healthMo
 		qf:              qf,
 		trackedIPs:      map[string]map[string]struct{}{},
 		trackedIPsMutex: &sync.Mutex{},
-		logger: logger,
+		logger:          logger,
 	}
 	go func() {
 		for {

--- a/src/bosh-dns/dns/server/tracker/tracker_test.go
+++ b/src/bosh-dns/dns/server/tracker/tracker_test.go
@@ -20,7 +20,7 @@ var _ = Describe("Tracker", func() {
 		shutdown       chan struct{}
 		hw             *fakes.Healther
 		qf             *fakes.Query
-		fakeLogger            *logfake.FakeLogger
+		fakeLogger     *logfake.FakeLogger
 	)
 
 	BeforeEach(func() {

--- a/src/bosh-dns/dns/shuffle/answer_shuffle.go
+++ b/src/bosh-dns/dns/shuffle/answer_shuffle.go
@@ -34,6 +34,6 @@ func (s AnswerShuffle) Shuffle(src []dns.RR) []dns.RR {
 
 func (s AnswerShuffle) remove(index int, recs []dns.RR) []dns.RR {
 	copy(recs[index:], recs[index+1:]) // left shift
-	recs = recs[:len(recs)-1] // truncate
+	recs = recs[:len(recs)-1]          // truncate
 	return recs
 }

--- a/src/bosh-dns/dns/shuffle/resolver_shuffle.go
+++ b/src/bosh-dns/dns/shuffle/resolver_shuffle.go
@@ -32,6 +32,6 @@ func (s StringShuffle) Shuffle(src []string) []string {
 
 func (s StringShuffle) remove(index int, strs []string) []string {
 	copy(strs[index:], strs[index+1:]) // left shift
-	strs = strs[:len(strs)-1] // truncate
+	strs = strs[:len(strs)-1]          // truncate
 	return strs
 }

--- a/src/bosh-dns/healthcheck/healthexecutable/monitor_unix.go
+++ b/src/bosh-dns/healthcheck/healthexecutable/monitor_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package healthexecutable

--- a/src/bosh-dns/healthcheck/healthserver/health_server.go
+++ b/src/bosh-dns/healthcheck/healthserver/health_server.go
@@ -27,8 +27,8 @@ type HealthExecutable interface {
 type concreteHealthServer struct {
 	logger           boshlog.Logger
 	healthExecutable HealthExecutable
-	shutdown chan struct{}
-	timeout time.Duration
+	shutdown         chan struct{}
+	timeout          time.Duration
 }
 
 const logTag = "healthServer"
@@ -37,8 +37,8 @@ func NewHealthServer(logger boshlog.Logger, healthFileName string, healthExecuta
 	return &concreteHealthServer{
 		logger:           logger,
 		healthExecutable: healthExecutable,
-		shutdown: shutdown,
-		timeout: timeout,
+		shutdown:         shutdown,
+		timeout:          timeout,
 	}
 }
 
@@ -58,16 +58,16 @@ func (c *concreteHealthServer) Serve(config *healthconfig.HealthCheckConfig) {
 	tlsConfig.BuildNameToCertificate()
 
 	server := &http.Server{
-		Addr:      fmt.Sprintf("%s:%d", config.Address, config.Port),
-		TLSConfig: tlsConfig,
-		ReadTimeout: c.timeout,
+		Addr:         fmt.Sprintf("%s:%d", config.Address, config.Port),
+		TLSConfig:    tlsConfig,
+		ReadTimeout:  c.timeout,
 		WriteTimeout: c.timeout,
 	}
 
 	go func() {
-		<- c.shutdown
+		<-c.shutdown
 		server.SetKeepAlivesEnabled(false)
-		ctx, _ := context.WithTimeout(context.Background(), 5 * time.Second)
+		ctx, _ := context.WithTimeout(context.Background(), 5*time.Second)
 		err = server.Shutdown(ctx)
 		if err != nil {
 			c.logger.Error(logTag, "http healthcheck error during shutdown %s", err)

--- a/src/bosh-dns/healthcheck/init_test.go
+++ b/src/bosh-dns/healthcheck/init_test.go
@@ -43,7 +43,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	serverPath, err := gexec.Build("bosh-dns/healthcheck")
 	Expect(err).NotTo(HaveOccurred())
 	SetDefaultEventuallyTimeout(2 * time.Second)
-	SetDefaultEventuallyPollingInterval(500*time.Millisecond)
+	SetDefaultEventuallyPollingInterval(500 * time.Millisecond)
 
 	return []byte(serverPath)
 }, func(data []byte) {

--- a/src/bosh-dns/healthcheck/main.go
+++ b/src/bosh-dns/healthcheck/main.go
@@ -46,9 +46,9 @@ func mainExitCode() int {
 	}
 
 	logger := boshlog.NewAsyncWriterLogger(logLevel, os.Stdout)
-    if config.LogFormat == "rfc3339" {
-        logger.UseRFC3339Timestamps()
-    }
+	if config.LogFormat == "rfc3339" {
+		logger.UseRFC3339Timestamps()
+	}
 	defer logger.FlushTimeout(5 * time.Second)
 	logger.Info(logTag, "Initializing")
 

--- a/src/bosh-dns/healthcheck/main_test.go
+++ b/src/bosh-dns/healthcheck/main_test.go
@@ -56,7 +56,7 @@ var _ = Describe("HealthCheck server", func() {
 				"assets/test_certs/test_ca.pem",
 				"assets/test_certs/test_client.pem",
 				"assets/test_certs/test_client.key",
-				5 * time.Second,
+				5*time.Second,
 				logger,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -153,7 +153,7 @@ var _ = Describe("HealthCheck server", func() {
 				"assets/test_certs/test_fake_ca.pem",
 				"assets/test_certs/test_fake_client.pem",
 				"assets/test_certs/test_client.key",
-				5 * time.Second,
+				5*time.Second,
 				logger,
 			)
 			Expect(err).NotTo(HaveOccurred())
@@ -169,7 +169,7 @@ var _ = Describe("HealthCheck server", func() {
 				"assets/test_certs/test_ca.pem",
 				"assets/test_certs/test_wrong_cn_client.pem",
 				"assets/test_certs/test_client.key",
-				5 * time.Second,
+				5*time.Second,
 				logger,
 			)
 			Expect(err).NotTo(HaveOccurred())

--- a/src/bosh-dns/healthconfig/config.go
+++ b/src/bosh-dns/healthconfig/config.go
@@ -18,6 +18,6 @@ type HealthCheckConfig struct {
 
 	RequestTimeout config.DurationJSON `json:"request_timeout"`
 
-	LogLevel string `json:"log_level"`
+	LogLevel  string `json:"log_level"`
 	LogFormat string `json:"log_format"`
 }

--- a/src/bosh-dns/integration-tests/health_server.go
+++ b/src/bosh-dns/integration-tests/health_server.go
@@ -224,7 +224,7 @@ func (t *testHealthServer) Start() error {
 		t.CAFile,
 		"../healthcheck/assets/test_certs/test_client.pem",
 		"../healthcheck/assets/test_certs/test_client.key",
-		5 * time.Second,
+		5*time.Second,
 		logger,
 	)
 	Expect(err).NotTo(HaveOccurred())

--- a/src/bosh-dns/integration-tests/health_test.go
+++ b/src/bosh-dns/integration-tests/health_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Integration", func() {
 						fmt.Sprintf("q-g0s0.bosh-dns.default.bosh-dns.bosh."), e.ServerAddress(),
 						helpers.DigOpts{Port: e.Port(), SkipRcodeCheck: true})
 					return dnsResponse.Answer
-				}, 5 *time.Second, 500*time.Millisecond).Should(ConsistOf(
+				}, 5*time.Second, 500*time.Millisecond).Should(ConsistOf(
 					gomegadns.MatchResponse(gomegadns.Response{
 						"ip":  "127.0.0.2",
 						"ttl": 0,

--- a/src/bosh-dns/integration-tests/recursors_test.go
+++ b/src/bosh-dns/integration-tests/recursors_test.go
@@ -226,7 +226,7 @@ var _ = Describe("Integration", func() {
 				Context("slow recursor", func() {
 					It("does not negative cache", func() {
 
-						dnsResponse := helpers.DigWithOptions("alternating-slow-recursor.com.", environment.ServerAddress(), helpers.DigOpts{Id: 1, Timeout: 5*time.Second, Port: environment.Port(), SkipRcodeCheck: true, SkipErrCheck: true})
+						dnsResponse := helpers.DigWithOptions("alternating-slow-recursor.com.", environment.ServerAddress(), helpers.DigOpts{Id: 1, Timeout: 5 * time.Second, Port: environment.Port(), SkipRcodeCheck: true, SkipErrCheck: true})
 
 						Expect(dnsResponse.Rcode).To(Equal(dns.RcodeNameError))
 						Expect(dnsResponse.Answer).To(HaveLen(0))
@@ -466,7 +466,7 @@ var _ = Describe("Integration", func() {
 						secondTestRecursor.stop()
 
 						helpers.DigWithOptions(testQuestion, environment.ServerAddress(),
-						helpers.DigOpts{Port: environment.Port(), SkipErrCheck: true, SkipRcodeCheck: true})
+							helpers.DigOpts{Port: environment.Port(), SkipErrCheck: true, SkipRcodeCheck: true})
 						Eventually(environment.Output(), 5*time.Second, 500*time.Millisecond).Should(gbytes.Say(`no response from recursors`))
 					})
 				})

--- a/src/bosh-dns/integration-tests/smoke_test.go
+++ b/src/bosh-dns/integration-tests/smoke_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Integration", func() {
 			}}
 			hosts = []record.Host{
 				{
-					IP: "234.234.234.234",
+					IP:   "234.234.234.234",
 					FQDN: "abcdabcd.group.network.deployment.domain",
 				},
 			}

--- a/src/bosh-dns/integration-tests/test_environment.go
+++ b/src/bosh-dns/integration-tests/test_environment.go
@@ -104,7 +104,7 @@ func (t *testEnvironment) writeConfig() error {
 		Cache: config.Cache{
 			Enabled: t.caching,
 		},
-		RequestTimeout: config.DurationJSON(time.Second),
+		RequestTimeout:  config.DurationJSON(time.Second),
 		RecursorTimeout: config.DurationJSON(time.Second),
 	}
 

--- a/src/bosh-dns/performance_tests/health_test.go
+++ b/src/bosh-dns/performance_tests/health_test.go
@@ -92,7 +92,7 @@ func setupSecureGet() *httpclient.HTTPClient {
 
 	logger := boshlog.NewAsyncWriterLogger(boshlog.LevelDebug, ioutil.Discard)
 
-	client, err := tlsclient.New("health.bosh-dns", caCert, cert, 5 * time.Second, logger)
+	client, err := tlsclient.New("health.bosh-dns", caCert, cert, 5*time.Second, logger)
 	Expect(err).NotTo(HaveOccurred())
 	return client
 }

--- a/src/bosh-dns/performance_tests/init_test.go
+++ b/src/bosh-dns/performance_tests/init_test.go
@@ -43,7 +43,7 @@ func setupServers() {
 	Expect(err).NotTo(HaveOccurred())
 
 	SetDefaultEventuallyTimeout(2 * time.Second)
-	SetDefaultEventuallyPollingInterval(500*time.Millisecond)
+	SetDefaultEventuallyPollingInterval(500 * time.Millisecond)
 
 	for i := 2; i <= 102; i++ {
 		startHealthServer(fmt.Sprintf("127.0.0.%d", i))

--- a/src/bosh-dns/tlsclient/client.go
+++ b/src/bosh-dns/tlsclient/client.go
@@ -7,8 +7,9 @@ import (
 
 	"net/http"
 
-	"code.cloudfoundry.org/tlsconfig"
 	"crypto/x509"
+
+	"code.cloudfoundry.org/tlsconfig"
 
 	"github.com/cloudfoundry/bosh-utils/httpclient"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"

--- a/src/bosh-dns/tools/tools.go
+++ b/src/bosh-dns/tools/tools.go
@@ -1,9 +1,10 @@
+//go:build tools
 // +build tools
 
 package tools
 
 import (
-  _ "github.com/onsi/ginkgo/ginkgo" // comment to make golint happy
+	_ "github.com/onsi/ginkgo/ginkgo" // comment to make golint happy
 )
 
 // This file imports packages that are used when running go generate, or used

--- a/src/bosh-dns/wait/init_test.go
+++ b/src/bosh-dns/wait/init_test.go
@@ -23,7 +23,7 @@ var _ = SynchronizedBeforeSuite(func() []byte {
 	waitPath, err := gexec.Build("bosh-dns/wait")
 	Expect(err).NotTo(HaveOccurred())
 	SetDefaultEventuallyTimeout(2 * time.Second)
-	SetDefaultEventuallyPollingInterval(500*time.Millisecond)
+	SetDefaultEventuallyPollingInterval(500 * time.Millisecond)
 
 	return []byte(waitPath)
 }, func(data []byte) {

--- a/src/bosh-dns/wait/main.go
+++ b/src/bosh-dns/wait/main.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"github.com/cloudfoundry/bosh-utils/logger"
 	"os"
 	"time"
+
+	"github.com/cloudfoundry/bosh-utils/logger"
 
 	"net"
 )
@@ -25,9 +26,9 @@ func main() {
 	success := make(chan bool)
 
 	log := logger.NewAsyncWriterLogger(logger.LevelDebug, os.Stdout)
-    if *logFormat == "rfc3339" {
-        log.UseRFC3339Timestamps()
-    }
+	if *logFormat == "rfc3339" {
+		log.UseRFC3339Timestamps()
+	}
 
 	resolver := getResolver(log, *address, *port)
 	log.Info("wait", "resolving %s", *domain)
@@ -49,11 +50,11 @@ func main() {
 	select {
 	case <-bomb.C:
 		log.Error("wait", "timeout")
-		log.FlushTimeout(5*time.Second)
+		log.FlushTimeout(5 * time.Second)
 		os.Exit(1)
 	case <-success:
 		log.Info("wait", "success")
-		log.FlushTimeout(5*time.Second)
+		log.FlushTimeout(5 * time.Second)
 		os.Exit(0)
 	}
 }

--- a/src/debug/cli/command/instances_cmd.go
+++ b/src/debug/cli/command/instances_cmd.go
@@ -35,7 +35,7 @@ func (o *InstancesCmd) Execute(args []string) error {
 		o.UI = confUI
 	}
 
-	client, err := tlsclient.NewFromFiles("api.bosh-dns", o.TLSCACertPath, o.TLSCertificatePath, o.TLSPrivateKeyPath, 5 * time.Second, logger)
+	client, err := tlsclient.NewFromFiles("api.bosh-dns", o.TLSCACertPath, o.TLSCertificatePath, o.TLSPrivateKeyPath, 5*time.Second, logger)
 	if err != nil {
 		return err
 	}

--- a/src/debug/cli/command/local_groups_cmd.go
+++ b/src/debug/cli/command/local_groups_cmd.go
@@ -30,7 +30,7 @@ func (o *LocalGroupsCmd) Execute(args []string) error {
 		o.UI = confUI
 	}
 
-	client, err := tlsclient.NewFromFiles("api.bosh-dns", o.TLSCACertPath, o.TLSCertificatePath, o.TLSPrivateKeyPath, 5 * time.Second, logger)
+	client, err := tlsclient.NewFromFiles("api.bosh-dns", o.TLSCACertPath, o.TLSCertificatePath, o.TLSPrivateKeyPath, 5*time.Second, logger)
 	if err != nil {
 		return err
 	}

--- a/src/debug/tools/tools.go
+++ b/src/debug/tools/tools.go
@@ -1,9 +1,10 @@
+//go:build tools
 // +build tools
 
 package tools
 
 import (
-  _ "github.com/onsi/ginkgo/ginkgo" // comment to make golint happy
+	_ "github.com/onsi/ginkgo/ginkgo" // comment to make golint happy
 )
 
 // This file imports packages that are used when running go generate, or used

--- a/src/debug/vendor/bosh-dns/dns/manager/syscall_windows.go
+++ b/src/debug/vendor/bosh-dns/dns/manager/syscall_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package manager

--- a/src/debug/vendor/bosh-dns/healthconfig/config.go
+++ b/src/debug/vendor/bosh-dns/healthconfig/config.go
@@ -18,6 +18,6 @@ type HealthCheckConfig struct {
 
 	RequestTimeout config.DurationJSON `json:"request_timeout"`
 
-	LogLevel string `json:"log_level"`
+	LogLevel  string `json:"log_level"`
 	LogFormat string `json:"log_format"`
 }

--- a/src/debug/vendor/bosh-dns/tlsclient/client.go
+++ b/src/debug/vendor/bosh-dns/tlsclient/client.go
@@ -7,8 +7,9 @@ import (
 
 	"net/http"
 
-	"code.cloudfoundry.org/tlsconfig"
 	"crypto/x509"
+
+	"code.cloudfoundry.org/tlsconfig"
 
 	"github.com/cloudfoundry/bosh-utils/httpclient"
 	boshlog "github.com/cloudfoundry/bosh-utils/logger"


### PR DESCRIPTION
Ran `goimports -w .` within `src/bosh-dns` to reformat all of the go
files automatically.