### PR TITLE
Make SERVFAIL respond with SERVFAIL

### DIFF
--- a/src/bosh-dns/dns/server/handlers/forward_handler.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler.go
@@ -5,6 +5,7 @@ import (
 	"bosh-dns/dns/server/records/dnsresolver"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/clock"
@@ -116,7 +117,11 @@ func (r ForwardHandler) writeNoResponseMessage(responseWriter dns.ResponseWriter
 	case net.Error:
 		responseMessage.SetRcode(req, dns.RcodeServerFailure)
 	default:
-		responseMessage.SetRcode(req, dns.RcodeNameError)
+		if strings.Contains(err.Error(), "received SERVFAIL") {
+			responseMessage.SetRcode(req, dns.RcodeServerFailure)
+		} else {
+			responseMessage.SetRcode(req, dns.RcodeNameError)
+		}
 		break
 	}
 


### PR DESCRIPTION
If an upstream nameserver responds with SERVFAIL, then bosh-dns should respond with SERVFAIL.

What does this solve? One of our customers was using a domain, which had/has a fault that returned SERVFAIL...however, currently bosh-dns switches all non network errors to be an NXDOMAIN error. This meant our customers application was receiving an incorrect DNS response. By adding this code we are able to pass the SERVFAIL back to the customer correctly.