### PR TITLE
Make SERVFAIL respond with SERVFAIL

### DIFF
--- a/src/bosh-dns/dns/server/handlers/forward_handler.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler.go
@@ -5,6 +5,7 @@ import (
 	"bosh-dns/dns/server/records/dnsresolver"
 	"fmt"
 	"net"
+	"strings"
 	"time"
 
 	"code.cloudfoundry.org/clock"
@@ -116,7 +117,11 @@ func (r ForwardHandler) writeNoResponseMessage(responseWriter dns.ResponseWriter
 	case net.Error:
 		responseMessage.SetRcode(req, dns.RcodeServerFailure)
 	default:
-		responseMessage.SetRcode(req, dns.RcodeNameError)
+		if strings.Contains(err.Error(), "received SERVFAIL") {
+			responseMessage.SetRcode(req, dns.RcodeServerFailure)
+		} else {
+			responseMessage.SetRcode(req, dns.RcodeNameError)
+		}
 		break //nolint:gosimple
 	}
 

--- a/src/bosh-dns/dns/server/handlers/forward_handler.go
+++ b/src/bosh-dns/dns/server/handlers/forward_handler.go
@@ -5,7 +5,6 @@ import (
 	"bosh-dns/dns/server/records/dnsresolver"
 	"fmt"
 	"net"
-	"strings"
 	"time"
 
 	"code.cloudfoundry.org/clock"
@@ -33,6 +32,16 @@ type Cache interface {
 	Get(req *dns.Msg) *dns.Msg
 	Write(req, answer *dns.Msg)
 	GetExpired(*dns.Msg) *dns.Msg
+}
+
+type DnsError struct {
+  Rcode int
+  Question string
+  Recursor string
+}
+
+func (e DnsError) Error() string { 
+	return fmt.Sprintf("received %s for %s from upstream (recursor: %s)", dns.RcodeToString[e.Rcode], e.Question, e.Recursor)
 }
 
 func NewForwardHandler(recursors RecursorPool, exchangerFactory ExchangerFactory, clock clock.Clock, logger logger.Logger, truncater dnsresolver.ResponseTruncater) ForwardHandler {
@@ -66,11 +75,10 @@ func (r ForwardHandler) ServeDNS(responseWriter dns.ResponseWriter, request *dns
 			question := request.Question[0].Name
 			r.logger.Error(r.logTag, "error recursing for %s to %q: %s", question, recursor, err.Error())
 		}
-
 		if exchangeAnswer != nil && exchangeAnswer.MsgHdr.Rcode != dns.RcodeSuccess {
 			question := request.Question[0].Name
-			err = fmt.Errorf("received %s for %s from upstream (recursor: %s)", dns.RcodeToString[exchangeAnswer.MsgHdr.Rcode], question, recursor)
-			if exchangeAnswer.MsgHdr.Rcode == dns.RcodeNameError {
+      err = DnsError{Rcode: exchangeAnswer.MsgHdr.Rcode, Question: question, Recursor: recursor}
+      if exchangeAnswer.MsgHdr.Rcode == dns.RcodeNameError {
 				r.logger.Debug(r.logTag, "error recursing to %q: %s", recursor, err.Error())
 			} else {
 				r.logger.Error(r.logTag, "error recursing to %q: %s", recursor, err.Error())
@@ -116,12 +124,15 @@ func (r ForwardHandler) writeNoResponseMessage(responseWriter dns.ResponseWriter
 	switch err.(type) {
 	case net.Error:
 		responseMessage.SetRcode(req, dns.RcodeServerFailure)
+  case DnsError:
+    if err.(DnsError).Rcode == dns.RcodeServerFailure {
+      responseMessage.SetRcode(req, dns.RcodeServerFailure)
+    } else {
+      responseMessage.SetRcode(req, dns.RcodeNameError)
+    }
+    break //nolint:gosimple
 	default:
-		if strings.Contains(err.Error(), "received SERVFAIL") {
-			responseMessage.SetRcode(req, dns.RcodeServerFailure)
-		} else {
-			responseMessage.SetRcode(req, dns.RcodeNameError)
-		}
+		responseMessage.SetRcode(req, dns.RcodeNameError)
 		break //nolint:gosimple
 	}
 


### PR DESCRIPTION
If an upstream nameserver responds with SERVFAIL, then bosh-dns should respond with SERVFAIL.

What does this solve? One of our customers was using a domain, which had/has a fault that returned SERVFAIL...however, currently bosh-dns switches all non network errors to be an NXDOMAIN error. This meant our customers application was receiving an incorrect DNS response. By adding this code we are able to pass the SERVFAIL back to the customer correctly.

[duplicate PR because committer email was wrong]