### PR TITLE
Add systemd-resolved support

### DIFF
--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -34,10 +34,7 @@ packages:
 
 properties:
   address:
-    description: "Address in which the DNS server will bind"
-    default: 169.254.0.2
-  aliased_address:
-    description: "Address that will be added by default"
+    description: "Address which the DNS server will bind to"
     default: 169.254.0.2
   addresses_files_glob:
     description: "Glob for any files to look for extra addresses to listen on"
@@ -75,6 +72,10 @@ properties:
     description: "Configure ourselves as the system nameserver (e.g. /etc/resolv.conf will be watched and overwritten)"
     default: true
 
+  configure_systemd_resolved:
+    description: "Create a virtual interface so systemd-resolved can use bosh-dns to resolve queries"
+    default: false
+
   handlers:
     description: "Array of handler configurations"
     default: []
@@ -96,6 +97,9 @@ properties:
     description: "Glob for any files to look for DNS handler information"
     default: /var/vcap/jobs/*/dns/handlers.json
 
+  disable_recursors:
+    description: "When set to true, bosh-dns will only resolve bosh-dns queries and will never forward queries to recursors"
+    default: false
   recursors:
     description: "Addresses of upstream DNS servers used for recursively resolving queries"
     default: []

--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -37,16 +37,33 @@ function create_directories_and_chown_to_vcap() {
 }
 
 function create_network_alias() {
-  if ! ip addr show dev lo | grep -q <%= p('aliased_address') %>
+  if ! ip addr show dev lo | grep -q <%= p('address') %>
   then
     ip addr add <%= p('address') %> dev lo
   fi
 }
 
 function remove_network_alias() {
-  if ip addr show dev lo | grep -q <%= p('aliased_address') %>
+  if ip addr show dev lo | grep -q <%= p('address') %>
   then
     ip addr del <%= p('address') %>/32 dev lo
+  fi
+}
+
+function create_network_interface() {
+  if ! ip addr show dev bosh-dns
+  then
+    ip link add bosh-dns type dummy
+    ip addr add <%= p('address') %>/32 dev bosh-dns
+    ip link set bosh-dns up
+    resolvectl dns bosh-dns <%= p('address') %>
+  fi
+}
+
+function remove_network_interface() {
+  if ip addr show dev bosh-dns
+  then
+    ip link delete bosh-dns
   fi
 }
 
@@ -106,13 +123,22 @@ function main() {
 
   case ${1} in
     start)
+      <% if p('configure_systemd_resolved') -%>
+      create_network_interface
+      "${DNS_PACKAGE}/bin/bosh-dns-systemd-resolved-updater" --config "${JOB_DIR}/config/config.json"
+      <% else -%>
       create_network_alias
+      <% end -%>
       start_dns
       ;;
 
     stop)
       stop_dns
+      <% if p('configure_systemd_resolved') -%>
+      remove_network_interface
+      <% else -%>
       remove_network_alias
+      <% end -%>
       ;;
 
     *)

--- a/jobs/bosh-dns/templates/config.json.erb
+++ b/jobs/bosh-dns/templates/config.json.erb
@@ -3,6 +3,8 @@
   address: p('address'),
   port: p('port'),
   log_level: p('log_level'),
+  disable_recursors: p('disable_recursors'),
+  configure_systemd_resolved: p('configure_systemd_resolved'),
   recursors: p('recursors'),
   excluded_recursors: p('excluded_recursors'),
   records_file: p('records_file'),

--- a/packages/bosh-dns/packaging
+++ b/packages/bosh-dns/packaging
@@ -11,6 +11,7 @@ pushd "${GOPATH}/src/bosh-dns"
   go build -o "${BOSH_INSTALL_TARGET}/bin/bosh-dns-nameserverconfig" "bosh-dns/dns/nameserverconfig"
   go build -o "${BOSH_INSTALL_TARGET}/bin/bosh-dns-health" "bosh-dns/healthcheck"
   go build -o "${BOSH_INSTALL_TARGET}/bin/bosh-dns-wait" "bosh-dns/wait"
+  go build -o "${BOSH_INSTALL_TARGET}/bin/bosh-dns-systemd-resolved-updater" "bosh-dns/dns/systemdresolvedupdater"
 popd
 
 mv debug "${GOPATH}/src"

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -19,21 +19,23 @@ const (
 )
 
 type Config struct {
-	Address            string       `json:"address"`
-	Port               int          `json:"port"`
-	BindTimeout        DurationJSON `json:"timeout,omitempty"`
-	RecursorMaxRetries int          `json:"recursor_max_retries,omitempty"`
-	RequestTimeout     DurationJSON `json:"request_timeout,omitempty"`
-	RecursorTimeout    DurationJSON `json:"recursor_timeout,omitempty"`
-	Recursors          []string     `json:"recursors,omitempty"`
-	ExcludedRecursors  []string     `json:"excluded_recursors,omitempty"`
-	RecordsFile        string       `json:"records_file,omitempty"`
-	RecursorSelection  string       `json:"recursor_selection"`
-	AliasFilesGlob     string       `json:"alias_files_glob,omitempty"`
-	HandlersFilesGlob  string       `json:"handlers_files_glob,omitempty"`
-	AddressesFilesGlob string       `json:"addresses_files_glob,omitempty"`
-	UpcheckDomains     []string     `json:"upcheck_domains,omitempty"`
-	JobsDir            string       `json:"jobs_dir,omitempty"`
+	Address                  string       `json:"address"`
+	Port                     int          `json:"port"`
+	BindTimeout              DurationJSON `json:"timeout,omitempty"`
+	RecursorMaxRetries       int          `json:"recursor_max_retries,omitempty"`
+	RequestTimeout           DurationJSON `json:"request_timeout,omitempty"`
+	RecursorTimeout          DurationJSON `json:"recursor_timeout,omitempty"`
+	Recursors                []string     `json:"recursors,omitempty"`
+	DisableRecursors         bool         `json:"disable_recursors,omitempty"`
+	ConfigureSystemdResolved bool         `json:"configure_systemd_resolved,omitempty"`
+	ExcludedRecursors        []string     `json:"excluded_recursors,omitempty"`
+	RecordsFile              string       `json:"records_file,omitempty"`
+	RecursorSelection        string       `json:"recursor_selection"`
+	AliasFilesGlob           string       `json:"alias_files_glob,omitempty"`
+	HandlersFilesGlob        string       `json:"handlers_files_glob,omitempty"`
+	AddressesFilesGlob       string       `json:"addresses_files_glob,omitempty"`
+	UpcheckDomains           []string     `json:"upcheck_domains,omitempty"`
+	JobsDir                  string       `json:"jobs_dir,omitempty"`
 
 	LogLevel string `json:"log_level,omitempty"`
 

--- a/src/bosh-dns/dns/manager/systemd_resolved_manager.go
+++ b/src/bosh-dns/dns/manager/systemd_resolved_manager.go
@@ -1,0 +1,21 @@
+package manager
+
+import "github.com/cloudfoundry/bosh-utils/system"
+
+type systemdResolvedManager struct {
+	cmdRunner system.CmdRunner
+}
+
+func NewSystemdResolvedManager(cmdRunner system.CmdRunner) systemdResolvedManager {
+	return systemdResolvedManager{
+		cmdRunner: cmdRunner,
+	}
+}
+
+func (r systemdResolvedManager) UpdateDomains(domains []string) error {
+	resolvectlArgs := []string{"domain", "bosh-dns"}
+	resolvectlArgs = append(resolvectlArgs, domains...)
+
+	_, _, _, err := r.cmdRunner.RunCommand("resolvectl", resolvectlArgs...)
+	return err
+}

--- a/src/bosh-dns/dns/manager/systemd_resolved_manager_test.go
+++ b/src/bosh-dns/dns/manager/systemd_resolved_manager_test.go
@@ -1,0 +1,32 @@
+package manager_test
+
+import (
+	"bosh-dns/dns/manager"
+
+	"github.com/cloudfoundry/bosh-utils/system/fakes"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("SystemdResolvedManager", func() {
+	var (
+		fakeCmdRunner *fakes.FakeCmdRunner
+	)
+
+	BeforeEach(func() {
+		fakeCmdRunner = fakes.NewFakeCmdRunner()
+	})
+
+	Describe("UpdateDomains", func() {
+		It("configures the Domains for the bosh-dns interface using resolvectl", func() {
+			fakeCmdRunner.AddCmdResult("resolvectl domain bosh-dns bosh. alias-domain.", fakes.FakeCmdResult{})
+
+			manager := manager.NewSystemdResolvedManager(fakeCmdRunner)
+
+			err := manager.UpdateDomains([]string{"bosh.", "alias-domain."})
+
+			Expect(err).NotTo(HaveOccurred())
+			Expect(fakeCmdRunner.RunCommands[0]).To(Equal([]string{"resolvectl", "domain", "bosh-dns", "bosh.", "alias-domain."}))
+		})
+	})
+})

--- a/src/bosh-dns/dns/systemdresolvedupdater/main.go
+++ b/src/bosh-dns/dns/systemdresolvedupdater/main.go
@@ -1,0 +1,71 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"time"
+
+	"bosh-dns/dns/config"
+	"bosh-dns/dns/manager"
+	"bosh-dns/dns/server/aliases"
+	"bosh-dns/dns/server/healthiness"
+	"bosh-dns/dns/server/records"
+
+	"code.cloudfoundry.org/clock"
+	"github.com/cloudfoundry/bosh-utils/logger"
+	"github.com/cloudfoundry/bosh-utils/system"
+)
+
+func main() {
+	var configPath string
+	flag.StringVar(&configPath, "config", "", "path to config file")
+	flag.Parse()
+
+	config, err := config.LoadFromFile(configPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	level, err := config.GetLogLevel()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	logger := logger.NewLogger(level)
+
+	clock := clock.NewClock()
+	shutdown := make(chan struct{})
+	fileReader := records.NewFileReader(config.RecordsFile, system.NewOsFileSystem(logger), clock, logger, shutdown)
+	fs := system.NewOsFileSystem(logger)
+	healthWatcher := healthiness.NewNopHealthWatcher()
+
+	aliasConfiguration, err := aliases.ConfigFromGlob(
+		fs,
+		aliases.NewFSLoader(fs),
+		config.AliasFilesGlob,
+	)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	filtererFactory := records.NewHealthFiltererFactory(healthWatcher, time.Duration(config.Health.SynchronousCheckTimeout))
+
+	recordSet, err := records.NewRecordSet(fileReader, aliasConfiguration, healthWatcher, uint(config.Health.MaxTrackedQueries), shutdown, logger, filtererFactory, records.NewAliasEncoder())
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+
+	if config.ConfigureSystemdResolved {
+		systemdResolvedManager := manager.NewSystemdResolvedManager(system.NewExecCmdRunner(logger))
+		err = systemdResolvedManager.UpdateDomains(recordSet.Domains())
+		if err != nil {
+			fmt.Fprintln(os.Stderr, err.Error())
+			os.Exit(1)
+		}
+	}
+	close(shutdown)
+}


### PR DESCRIPTION
systemd-resolved runs its own dns server which fans out queries to other servers it knows about. There are some global configs, but the primary discovery mechanism is via the DNS config for each network interface.

Each network interface has it's own DNS servers and systemd-resolved tracks a "current" one that it will send queries to. This makes it impossible to co-locate the bosh-dns configuration on an existing interface as sometimes it would not be the "current" server and would not receive queries.

For Jammy and prior stemcells we create an alias address on the loopback interface. With systemd-resolved we instead create a virtual network interface and bind the IP address to that. We also configure the "Domains" for the interface to be the bosh-dns domains and any discovered bosh-dns alias doamins. This is to prevent queries for bosh-dns addresses from being fanned out to the other dns servers.

Since systemd-resolved is already fanning out the queries to all servers in parallel, a "disable_recursors" configuration property was added to disable recursing behavior in bosh-dns. This required some reordering of main.go.

The "aliased_address" was also removed from the bosh-dns job as the only spot it was used didn't seem to make sense.