### PR TITLE
set resolved loglevel the same as configured in bosh-dns

### DIFF
--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -57,6 +57,7 @@ function create_network_interface() {
     ip addr add <%= p('address') %>/32 dev bosh-dns
     ip link set bosh-dns up
     resolvectl dns bosh-dns <%= p('address') %>
+    resolvectl log-level <%= p('log_level')%>
   fi
 }
 


### PR DESCRIPTION
we should set the log level for systemd-resolved the same as we configure it in bosh-dns
for better logging purposes