### PR TITLE
When removing recursors for Noble usage, we accidentally also removed handlers

### DIFF
--- a/src/bosh-dns/dns/config/handlers/handler_configs.go
+++ b/src/bosh-dns/dns/config/handlers/handler_configs.go
@@ -56,3 +56,11 @@ func (c HandlerConfigs) GenerateHandlers(factory HandlerFactory) (map[string]dns
 	}
 	return realHandlers, nil
 }
+
+func (c HandlerConfigs) HandlerDomains() []string {
+	domains := []string{}
+	for _, handlerConfig := range c {
+		domains = append(domains, handlerConfig.Domain)
+	}
+	return domains
+}

--- a/src/bosh-dns/dns/config/handlers/handler_configs_test.go
+++ b/src/bosh-dns/dns/config/handlers/handler_configs_test.go
@@ -9,17 +9,20 @@ import (
 )
 
 var _ = Describe("Handlers Configuration", func() {
+	var (
+		handlersConfig     HandlerConfigs
+		fakeHandlerFactory *FakeHandlerFactory
+	)
+	BeforeEach(func() {
+		fakeHandlerFactory = &FakeHandlerFactory{}
+	})
+
 	Describe("GenerateHandlers", func() {
 		var (
-			handlersConfig     HandlerConfigs
-			fakeHandlerFactory *FakeHandlerFactory
-			fakeJsonHandler    *FakeDnsHandler
-			fakeDnsHandler     *FakeDnsHandler
+			fakeJsonHandler *FakeDnsHandler
+			fakeDnsHandler  *FakeDnsHandler
 		)
-
 		BeforeEach(func() {
-			fakeHandlerFactory = &FakeHandlerFactory{}
-
 			fakeDnsHandler = &FakeDnsHandler{}
 			fakeJsonHandler = &FakeDnsHandler{}
 
@@ -172,6 +175,31 @@ var _ = Describe("Handlers Configuration", func() {
 				Expect(handlers["my-tld."]).To(Equal(fakeDnsHandler))
 				Expect(handlers["my-other-tld."]).To(Equal(fakeJsonHandler))
 			})
+		})
+	})
+
+	Describe("HandlerDomains", func() {
+		It("returns an empty set when no handlers configured", func() {
+			handlersConfig = HandlerConfigs{}
+
+			domains := handlersConfig.HandlerDomains()
+			Expect(len(domains)).To(Equal(0))
+		})
+
+		It("returns an domains when for each configured handler", func() {
+			handlersConfig = HandlerConfigs{
+				{
+					Domain: "first-tld.",
+				},
+				{
+					Domain: "second-tld.",
+				},
+				{
+					Domain: "nested.domain.",
+				},
+			}
+			domains := handlersConfig.HandlerDomains()
+			Expect(domains).To(Equal([]string{"first-tld.", "second-tld.", "nested.domain."}))
 		})
 	})
 })


### PR DESCRIPTION
These are essentially recursors, but for specific domains and are typically discovered via glob files on the VM. Main use case is bosh-dns-adapter used by diego to make container to container networking work.

We also update the startup tooling that configures systemd-resolved with the domains bosh-dns knows about to also include the domains configured by handlers.