### PR TITLE
envrc: remove empty file

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,3 +1,0 @@
-if command -v lorri &> /dev/null; then
-   eval "$(lorri direnv)"
-fi


### PR DESCRIPTION
only `lorri` was present, no settings