### PR TITLE
Feat: New race strategy

### DIFF
--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -110,7 +110,11 @@ properties:
     description: "Maximum number of retries for recursively resolving DNS queries"
     default: 0
   recursor_selection:
-    description: "The selection strategy for the recursors (serial or smart)"
+    description: |
+      The selection strategy for the recursors:
+      - "serial": Try recursors in order, no failure tracking
+      - "smart": Track failures and prefer reliable recursors (default, DNS spec compliant)
+      - "race": Query all recursors in parallel and use best/fastest response
     default: smart
   excluded_recursors:
     description: "A list of recursor addresses which should not be used by the DNS server"

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -196,8 +196,9 @@ func LoadFromFile(configFilePath string) (Config, error) {
 	switch c.RecursorSelection {
 	case "smart":
 	case "serial":
+	case "race":
 	default:
-		return Config{}, errors.New("invalid value for recursor_selection; expected 'serial' or 'smart'")
+		return Config{}, errors.New("invalid value for recursor_selection; expected 'serial', 'smart', or 'race'")
 	}
 
 	return c, nil

--- a/src/bosh-dns/dns/config/config.go
+++ b/src/bosh-dns/dns/config/config.go
@@ -15,6 +15,7 @@ import (
 const (
 	SmartRecursorSelection  = "smart"
 	SerialRecursorSelection = "serial"
+	RaceRecursorSelection   = "race"
 	RFCFormatting           = "rfc3339"
 )
 

--- a/src/bosh-dns/dns/config/config_test.go
+++ b/src/bosh-dns/dns/config/config_test.go
@@ -259,6 +259,15 @@ var _ = Describe("Config", func() {
 			Expect(dnsConfig.RecursorSelection).To(Equal("smart"))
 		})
 
+		It("allows configuring recursor selection to be race", func() {
+			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53, "recursor_selection": "race"}`)
+
+			dnsConfig, err := config.LoadFromFile(configFilePath)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(dnsConfig.RecursorSelection).To(Equal("race"))
+		})
+
 		It("defaults recursor selection to be smart", func() {
 			configFilePath := writeConfigFile(`{"address": "127.0.0.1", "port": 53 }`)
 

--- a/src/bosh-dns/dns/config/recursor.go
+++ b/src/bosh-dns/dns/config/recursor.go
@@ -52,6 +52,8 @@ func ConfigureRecursors(reader RecursorReader, dnsConfig *Config) error {
 		dnsConfig.Recursors = recursors
 	case SerialRecursorSelection:
 		dnsConfig.Recursors = recursors
+	case RaceRecursorSelection:
+		dnsConfig.Recursors = recursors
 	default:
 		return fmt.Errorf("invalid value for recursor selection: '%s'", dnsConfig.RecursorSelection)
 	}

--- a/src/bosh-dns/dns/config/recursor_test.go
+++ b/src/bosh-dns/dns/config/recursor_test.go
@@ -58,6 +58,19 @@ var _ = Describe("Recursor", func() {
 			})
 		})
 
+		Context("race", func() {
+			BeforeEach(func() {
+				dnsConfig.RecursorSelection = "race"
+				dnsConfig.Recursors = []string{"some-recursor-1:53", "some-recursor-2:53", "recursor-custom:1234"}
+			})
+
+			It("should not shuffle the recursors", func() {
+				err := config.ConfigureRecursors(resolvConfReader, &dnsConfig)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(dnsConfig.Recursors).Should(Equal([]string{"some-recursor-1:53", "some-recursor-2:53", "recursor-custom:1234"}))
+			})
+		})
+
 		Context("smart", func() {
 			var originalRecursors []string
 			BeforeEach(func() {

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
@@ -10,6 +10,7 @@ import (
 	"github.com/miekg/dns"
 
 	"bosh-dns/dns/config"
+	"bosh-dns/dns/server"
 )
 
 const (
@@ -41,11 +42,15 @@ func NewFailoverRecursorPool(recursors []string, recursorSelection string, Recur
 	recursorSettings := recursorRetrySettings{
 		maxRetries: RecursorMaxRetries,
 	}
-	if recursorSelection == config.SmartRecursorSelection {
-		return newSmartFailoverRecursorPool(recursors, recursorSettings, logger)
-	}
 
-	return newSerialFailoverRecursorPool(recursors, recursorSettings, logger)
+	switch recursorSelection {
+	case config.SmartRecursorSelection:
+		return newSmartFailoverRecursorPool(recursors, recursorSettings, logger)
+	case config.RaceRecursorSelection:
+		return newRaceRecursorPool(recursors, recursorSettings, logger)
+	default: // serial
+		return newSerialFailoverRecursorPool(recursors, recursorSettings, logger)
+	}
 }
 
 type serialFailoverRecursorPool struct {
@@ -74,6 +79,19 @@ type recursorWithHistory struct {
 	failCount  int32
 }
 
+type raceRecursorPool struct {
+	recursors             []string
+	logger                logger.Logger
+	logTag                string
+	recursorRetrySettings recursorRetrySettings
+}
+
+type raceResult struct {
+	recursor string
+	err      error
+	priority int // Lower is better: 0=success, 1=NXDOMAIN, 2=SERVFAIL, 3=network error
+}
+
 func newSerialFailoverRecursorPool(recursors []string, recursorSettings recursorRetrySettings, logger logger.Logger) RecursorPool {
 	return &serialFailoverRecursorPool{
 		recursors,
@@ -82,6 +100,19 @@ func newSerialFailoverRecursorPool(recursors []string, recursorSettings recursor
 		recursorSettings,
 	}
 
+}
+
+func newRaceRecursorPool(recursors []string, recursorSettings recursorRetrySettings, logger logger.Logger) RecursorPool {
+	if recursors == nil {
+		recursors = []string{}
+	}
+
+	return &raceRecursorPool{
+		recursors:             recursors,
+		logger:                logger,
+		logTag:                "RaceRecursor",
+		recursorRetrySettings: recursorSettings,
+	}
 }
 
 func newSmartFailoverRecursorPool(recursors []string, recursorSettings recursorRetrySettings, logger logger.Logger) RecursorPool {
@@ -188,4 +219,115 @@ func (q *smartFailoverRecursorPool) registerResult(index int, wasError bool) int
 	}
 
 	return atomic.AddInt32(&failingRecursor.failCount, change)
+}
+
+func (q *raceRecursorPool) PerformStrategically(work func(string) error) error {
+	if len(q.recursors) == 0 {
+		return ErrNoRecursorResponse
+	}
+
+	// Buffered channel sized to number of recursors - prevents goroutine blocking
+	results := make(chan raceResult, len(q.recursors))
+
+	// Start all queries in parallel
+	for _, recursor := range q.recursors {
+		go func(r string) {
+			err := performWithRetryLogic(work, r, q.recursorRetrySettings.maxRetries, q.logTag, q.logger)
+
+			// Classify the error by priority
+			priority := q.classifyError(err)
+
+			results <- raceResult{
+				recursor: r,
+				err:      err,
+				priority: priority,
+			}
+		}(recursor)
+	}
+
+	// Collect all results
+	var bestResult *raceResult
+	receivedCount := 0
+	totalRecursors := len(q.recursors)
+
+	for receivedCount < totalRecursors {
+		res := <-results
+		receivedCount++
+
+		q.logger.Debug(q.logTag, fmt.Sprintf(
+			"received response %d/%d from %s (priority=%d, err=%v)",
+			receivedCount, totalRecursors, res.recursor, res.priority, res.err))
+
+		// Keep track of best result so far
+		if bestResult == nil || res.priority < bestResult.priority {
+			bestResult = &res
+		}
+
+		// If we got a perfect response (NOERROR), return immediately
+		// Don't wait for other responses
+		if res.priority == 0 {
+			q.logger.Info(q.logTag, fmt.Sprintf(
+				"recursor %s returned successful response (received %d/%d responses)",
+				res.recursor, receivedCount, totalRecursors))
+
+			// Drain remaining responses to prevent goroutine leaks
+			go q.drainResults(results, totalRecursors-receivedCount)
+
+			return nil
+		}
+
+		// For non-success responses, continue collecting to see if we get a better one
+	}
+
+	// All responses received, return best one
+	if bestResult == nil {
+		return ErrNoRecursorResponse
+	}
+
+	if bestResult.err != nil {
+		q.logger.Info(q.logTag, fmt.Sprintf(
+			"all %d recursors responded, best result from %s (priority=%d): %s",
+			totalRecursors, bestResult.recursor, bestResult.priority, bestResult.err.Error()))
+	} else {
+		q.logger.Info(q.logTag, fmt.Sprintf(
+			"all %d recursors responded, using result from %s",
+			totalRecursors, bestResult.recursor))
+	}
+
+	return bestResult.err
+}
+
+// classifyError assigns priority to errors
+// Lower number = better response
+func (q *raceRecursorPool) classifyError(err error) int {
+	if err == nil {
+		return 0 // NOERROR - perfect response
+	}
+
+	// Check if it's a DNS error with rcode
+	if dnsErr, ok := err.(server.DnsError); ok {
+		switch dnsErr.Rcode() {
+		case dns.RcodeNameError: // NXDOMAIN
+			return 1 // Name doesn't exist - could be correct, but prefer NOERROR
+		case dns.RcodeServerFailure: // SERVFAIL
+			return 2 // Server failure - prefer NXDOMAIN over this
+		default:
+			return 2 // Other DNS errors
+		}
+	}
+
+	// Network errors are worst
+	if _, ok := err.(net.Error); ok {
+		return 3
+	}
+
+	// Unknown errors
+	return 3
+}
+
+// drainResults reads remaining results to prevent goroutine blocking
+func (q *raceRecursorPool) drainResults(results chan raceResult, remaining int) {
+	for i := 0; i < remaining; i++ {
+		<-results
+	}
 }

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool.go
@@ -36,6 +36,9 @@ type RecursorPool interface {
 // the server starting.  It does track history around which recursors have
 // failed. This follows the standard DNS specification.
 //
+// When it is "race", the recursor pool will query all recursors simultaneously
+// and return the first successful response.
+//
 // Each recursor will be queried until one succeeds or all recursors were tried
 
 func NewFailoverRecursorPool(recursors []string, recursorSelection string, RecursorMaxRetries int, logger logger.Logger) RecursorPool {
@@ -226,15 +229,12 @@ func (q *raceRecursorPool) PerformStrategically(work func(string) error) error {
 		return ErrNoRecursorResponse
 	}
 
-	// Buffered channel sized to number of recursors - prevents goroutine blocking
 	results := make(chan raceResult, len(q.recursors))
 
-	// Start all queries in parallel
 	for _, recursor := range q.recursors {
 		go func(r string) {
 			err := performWithRetryLogic(work, r, q.recursorRetrySettings.maxRetries, q.logTag, q.logger)
 
-			// Classify the error by priority
 			priority := q.classifyError(err)
 
 			results <- raceResult{
@@ -245,7 +245,6 @@ func (q *raceRecursorPool) PerformStrategically(work func(string) error) error {
 		}(recursor)
 	}
 
-	// Collect all results
 	var bestResult *raceResult
 	receivedCount := 0
 	totalRecursors := len(q.recursors)
@@ -258,28 +257,21 @@ func (q *raceRecursorPool) PerformStrategically(work func(string) error) error {
 			"received response %d/%d from %s (priority=%d, err=%v)",
 			receivedCount, totalRecursors, res.recursor, res.priority, res.err))
 
-		// Keep track of best result so far
 		if bestResult == nil || res.priority < bestResult.priority {
 			bestResult = &res
 		}
 
-		// If we got a perfect response (NOERROR), return immediately
-		// Don't wait for other responses
 		if res.priority == 0 {
 			q.logger.Info(q.logTag, fmt.Sprintf(
 				"recursor %s returned successful response (received %d/%d responses)",
 				res.recursor, receivedCount, totalRecursors))
 
-			// Drain remaining responses to prevent goroutine leaks
 			go q.drainResults(results, totalRecursors-receivedCount)
 
 			return nil
 		}
-
-		// For non-success responses, continue collecting to see if we get a better one
 	}
 
-	// All responses received, return best one
 	if bestResult == nil {
 		return ErrNoRecursorResponse
 	}
@@ -297,18 +289,15 @@ func (q *raceRecursorPool) PerformStrategically(work func(string) error) error {
 	return bestResult.err
 }
 
-// classifyError assigns priority to errors
-// Lower number = better response
 func (q *raceRecursorPool) classifyError(err error) int {
 	if err == nil {
 		return 0 // NOERROR - perfect response
 	}
 
-	// Check if it's a DNS error with rcode
 	if dnsErr, ok := err.(server.DnsError); ok {
 		switch dnsErr.Rcode() {
 		case dns.RcodeNameError: // NXDOMAIN
-			return 1 // Name doesn't exist - could be correct, but prefer NOERROR
+			return 1 // Name doesn't exist - could be correct, but prefer NOERROR to ignore temporary broken recursors
 		case dns.RcodeServerFailure: // SERVFAIL
 			return 2 // Server failure - prefer NXDOMAIN over this
 		default:
@@ -316,16 +305,13 @@ func (q *raceRecursorPool) classifyError(err error) int {
 		}
 	}
 
-	// Network errors are worst
 	if _, ok := err.(net.Error); ok {
 		return 3
 	}
 
-	// Unknown errors
 	return 3
 }
 
-// drainResults reads remaining results to prevent goroutine blocking
 func (q *raceRecursorPool) drainResults(results chan raceResult, remaining int) {
 	for i := 0; i < remaining; i++ {
 		<-results

--- a/src/bosh-dns/dns/server/handlers/failover_recursor_pool_test.go
+++ b/src/bosh-dns/dns/server/handlers/failover_recursor_pool_test.go
@@ -3,6 +3,7 @@ package handlers_test
 import (
 	"errors"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/cloudfoundry/bosh-utils/logger/loggerfakes"
@@ -10,6 +11,7 @@ import (
 	. "github.com/onsi/gomega"
 
 	"bosh-dns/dns/config"
+	"bosh-dns/dns/server"
 	. "bosh-dns/dns/server/handlers"
 )
 
@@ -308,6 +310,210 @@ var _ = Describe("RecursorPool", func() {
 
 			Expect(called).To(Equal(4))
 			Expect(err).ToNot(HaveOccurred())
+		})
+	})
+
+	Context(`when recursor selection is "race"`, func() {
+		var (
+			fakeLogger *loggerfakes.FakeLogger
+		)
+
+		BeforeEach(func() {
+			fakeLogger = &loggerfakes.FakeLogger{}
+		})
+
+		It("returns an error if there are no recursors configured", func() {
+			pool := NewFailoverRecursorPool([]string{}, config.RaceRecursorSelection, 0, fakeLogger)
+			Expect(pool.PerformStrategically(func(string) error { return nil })).To(Equal(ErrNoRecursorResponse))
+
+			pool = NewFailoverRecursorPool(nil, config.RaceRecursorSelection, 0, fakeLogger)
+			Expect(pool.PerformStrategically(func(string) error { return nil })).To(Equal(ErrNoRecursorResponse))
+		})
+
+		It("queries all recursors in parallel", func() {
+			callCount := make(map[string]int)
+			var mu sync.Mutex
+			started := make(chan string, 3)
+			pool := NewFailoverRecursorPool([]string{"one", "two", "three"}, config.RaceRecursorSelection, 0, fakeLogger)
+
+			err := pool.PerformStrategically(func(recursor string) error {
+				started <- recursor // Signal that this recursor was called
+				mu.Lock()
+				callCount[recursor]++
+				mu.Unlock()
+				// Return an error so we don't return early - we want to verify all are called
+				return errors.New("test error")
+			})
+
+			// All should have been started
+			Expect(err).To(HaveOccurred())
+			close(started)
+
+			startedRecursors := make(map[string]bool)
+			for r := range started {
+				startedRecursors[r] = true
+			}
+
+			Expect(len(startedRecursors)).To(Equal(3))
+			Expect(startedRecursors["one"]).To(BeTrue())
+			Expect(startedRecursors["two"]).To(BeTrue())
+			Expect(startedRecursors["three"]).To(BeTrue())
+		})
+
+		It("returns immediately on first NOERROR response", func() {
+			completionOrder := make(chan string, 3)
+			pool := NewFailoverRecursorPool([]string{"slow", "fast", "slower"}, config.RaceRecursorSelection, 0, fakeLogger)
+
+			err := pool.PerformStrategically(func(recursor string) error {
+				defer func() { completionOrder <- recursor }()
+
+				switch recursor {
+				case "fast":
+					// Fast recursor - returns immediately
+					return nil
+				case "slow":
+					time.Sleep(50 * time.Millisecond)
+					return nil
+				case "slower":
+					time.Sleep(100 * time.Millisecond)
+					return nil
+				}
+				return errors.New("unknown")
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			// Should return fast since it's the first success
+			firstCompleted := <-completionOrder
+			Expect(firstCompleted).To(Equal("fast"))
+		})
+
+		It("waits for all responses when no NOERROR is received and picks best", func() {
+			pool := NewFailoverRecursorPool([]string{"servfail", "nxdomain", "neterr"}, config.RaceRecursorSelection, 0, fakeLogger)
+
+			netErr := &net.DNSError{
+				Err:       "connection refused",
+				IsTimeout: false,
+			}
+
+			err := pool.PerformStrategically(func(recursor string) error {
+				switch recursor {
+				case "servfail":
+					// SERVFAIL (priority 2)
+					return server.NewDnsError(2, "test.com", recursor) // dns.RcodeServerFailure = 2
+				case "nxdomain":
+					// NXDOMAIN (priority 1) - should be picked as best
+					return server.NewDnsError(3, "test.com", recursor) // dns.RcodeNameError = 3
+				case "neterr":
+					// Network error (priority 3)
+					return netErr
+				}
+				return nil
+			})
+
+			// Should return NXDOMAIN error as it has the best priority (1)
+			Expect(err).To(HaveOccurred())
+			dnsErr, ok := err.(server.DnsError)
+			Expect(ok).To(BeTrue())
+			Expect(dnsErr.Rcode()).To(Equal(3)) // dns.RcodeNameError
+		})
+
+		It("handles all recursors failing", func() {
+			pool := NewFailoverRecursorPool([]string{"one", "two", "three"}, config.RaceRecursorSelection, 0, fakeLogger)
+
+			netErr := &net.DNSError{
+				Err:       "i/o timeout",
+				IsTimeout: true,
+			}
+
+			err := pool.PerformStrategically(func(recursor string) error {
+				return netErr
+			})
+
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(Equal(netErr))
+		})
+
+		It("handles mixed responses and returns NOERROR when present", func() {
+			pool := NewFailoverRecursorPool([]string{"nxdomain", "noerror", "servfail"}, config.RaceRecursorSelection, 0, fakeLogger)
+
+			err := pool.PerformStrategically(func(recursor string) error {
+				switch recursor {
+				case "nxdomain":
+					time.Sleep(20 * time.Millisecond)
+					return server.NewDnsError(3, "test.com", recursor) // dns.RcodeNameError
+				case "noerror":
+					time.Sleep(30 * time.Millisecond)
+					return nil // Success!
+				case "servfail":
+					time.Sleep(10 * time.Millisecond)
+					return server.NewDnsError(2, "test.com", recursor) // dns.RcodeServerFailure
+				}
+				return errors.New("unknown")
+			})
+
+			// Even though servfail completes first, we should wait and return NOERROR
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("can handle concurrent requests", func() {
+			pool := NewFailoverRecursorPool([]string{"one", "two"}, config.RaceRecursorSelection, 0, fakeLogger)
+
+			smash := func(done chan struct{}) {
+				defer func() { done <- struct{}{} }()
+				for i := 0; i < 20; i++ {
+					err := pool.PerformStrategically(func(n string) error {
+						time.Sleep(time.Millisecond)
+						return nil
+					})
+					Expect(err).NotTo(HaveOccurred())
+				}
+			}
+
+			done := make(chan struct{})
+
+			go smash(done)
+			go smash(done)
+			go smash(done)
+
+			for i := 0; i < 3; i++ {
+				select {
+				case <-done:
+					continue
+				case <-time.After(time.Minute):
+					Fail("reached something like a deadlock")
+				}
+			}
+		})
+
+		It("works with retry logic", func() {
+			pool := NewFailoverRecursorPool([]string{"retry1", "retry2"}, config.RaceRecursorSelection, 2, fakeLogger)
+
+			callCount := make(map[string]int)
+			var mu sync.Mutex
+			netErr := &net.DNSError{
+				Err:       "i/o timeout",
+				IsTimeout: true,
+			}
+
+			err := pool.PerformStrategically(func(recursor string) error {
+				mu.Lock()
+				callCount[recursor]++
+				count := callCount[recursor]
+				mu.Unlock()
+				// retry1 succeeds on 3rd attempt, retry2 always fails
+				if recursor == "retry1" && count >= 3 {
+					return nil
+				}
+				return netErr
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+			mu.Lock()
+			defer mu.Unlock()
+			// retry1 should have been called 3 times (initial + 2 retries)
+			Expect(callCount["retry1"]).To(Equal(3))
+			// retry2 should have been called 3 times as well (runs in parallel)
+			Expect(callCount["retry2"]).To(Equal(3))
 		})
 	})
 })


### PR DESCRIPTION
This PR is for adding a new Recursor Selection Option. This option should allow to forward requests to all recursors in parallel and take the fastest, good response. This mimics the behavior or bind and dnsmasq to improve dns resiliency against a set of recursors. 