### PR TITLE
CI: add newly required BATs inputs / params for director stemcell

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -402,7 +402,7 @@ jobs:
               - get: director-stemcell
                 resource: warden-noble-stemcell
               - get: bosh-release
-              - get: docker-cpi-image-noble
+              - get: docker-cpi-image
               - get: bosh-integration-image
           - task: create-candidate
             file: bosh-dns-release/ci/tasks/create-candidate.yml
@@ -411,7 +411,7 @@ jobs:
               candidate-release: bosh-dns-release
           - task: test-brats # contain base manifest
             file: bosh/ci/shared/brats/test-acceptance.yml
-            image: docker-cpi-image-noble
+            image: docker-cpi-image
             privileged: true
             input_mapping:
               dns-release: candidate-release
@@ -686,17 +686,9 @@ resources:
     type: registry-image
     source:
       tag: main
-      repository: bosh/docker-cpi
-      username: ((docker.username))
-      password: ((docker.password))
-
-  - name: docker-cpi-image-noble
-    type: registry-image
-    source:
-      tag: noble
-      repository: bosh/docker-cpi
-      username: ((docker.username))
-      password: ((docker.password))
+      repository: ghcr.io/cloudfoundry/bosh/docker-cpi
+      username: ((github_read_write_packages.username))
+      password: ((github_read_write_packages.password))
 
   - name: bosh-integration-image
     type: docker-image

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -362,6 +362,8 @@ jobs:
               - get: bosh
               - get: stemcell
                 resource: warden-jammy-stemcell
+              - get: director-stemcell
+                resource: warden-jammy-stemcell
               - get: bosh-release
               - get: docker-cpi-image
               - get: bosh-integration-image
@@ -383,7 +385,8 @@ jobs:
               DNS_RELEASE_FILE_PATH: "dns-release"
               DNS_RELEASE_VERSION: "create"
               FOCUS_SPEC: "BoshDns"
-              STEMCELL_OS: "ubuntu-jammy"
+              DIRECTOR_STEMCELL_OS: ubuntu-jammy
+              STEMCELL_OS: ubuntu-jammy
 
   - name: brats-ubuntu-noble
     serial: true
@@ -395,6 +398,8 @@ jobs:
                 trigger: true
               - get: bosh
               - get: stemcell
+                resource: warden-noble-stemcell
+              - get: director-stemcell
                 resource: warden-noble-stemcell
               - get: bosh-release
               - get: docker-cpi-image-noble
@@ -417,7 +422,8 @@ jobs:
               DNS_RELEASE_FILE_PATH: "dns-release"
               DNS_RELEASE_VERSION: "create"
               FOCUS_SPEC: "BoshDns"
-              STEMCELL_OS: "ubuntu-noble"
+              DIRECTOR_STEMCELL_OS: ubuntu-noble
+              STEMCELL_OS: ubuntu-noble
 
   - name: release-new-patch
     serial_groups:


### PR DESCRIPTION
NOTE: This config has already been applied to concourse

In both "jammy" and "noble" bats tests are configured to use the docker-cpi based on Noble, though they each use their respective noble / jammy container stemcell ("warden stemcell") as we no longer publish a jammy based docker-cpi image.

It isn't clear whether we should continue to attempt to test jammy in this context as the underlying Concourse VM's are using Noble, and hence the kernel at play in these specs is the Noble kernel / cgroups v2 and not Jammy / cgroups v1.