### PR TITLE
CI: stop persisting bbl state

### DIFF
--- a/ci/assets/utils.sh
+++ b/ci/assets/utils.sh
@@ -1,42 +1,6 @@
 #!/bin/bash
 set -eu -o pipefail
 
-kill_ssh() {
-  # kill the ssh tunnel to jumpbox, set up by bbl env
-  # (or task will hang forever)
-  pkill ssh || true
-}
-
-source_bbl_env() {
-  local bbl_state_dir=${1?'BBL state directory is required.'}
-
-  trap kill_ssh EXIT
-
-  set +x
-  eval "$(bbl print-env --state-dir="$bbl_state_dir")"
-  set -x
-}
-
-commit_bbl_state_dir() {
-  local input_dir=${1?'Input git repository absolute path is required.'}
-  local bbl_state_dir=${2?'BBL state relative path is required.'}
-  local output_dir=${3?'Output git repository absolute path is required.'}
-  local commit_message=${4:-'Update bbl state.'}
-
-  pushd "${input_dir}/${bbl_state_dir}"
-    if [[ -n $(git status --porcelain) ]]; then
-      git config user.name "CI Bot"
-      git config user.email "cf-release-integration@pivotal.io"
-      git add --all .
-      rm -f ../.git/hooks/prepare-commit-msg
-      git commit -m "${commit_message}"
-    fi
-  popd
-
-  shopt -s dotglob
-  cp -R "${input_dir}/." "${output_dir}"
-}
-
 delete_deployment() {
   local deployment_name="$1"
   set +e
@@ -46,6 +10,11 @@ delete_deployment() {
 
 clean_up_director() {
   local deployment_name=${1:-""}
+
+  if ! bosh env; then
+    echo 'No director found'
+    return
+  fi
 
   # Ensure the environment is clean
   if [[ -z "$deployment_name" ]]; then

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -232,7 +232,6 @@ jobs:
               passed:
                 - pre-integration-fan-in
               trigger: true
-            - get: envs
             - get: bosh-deployment
             - get: linux-stemcell
               resource: aws-jammy-stemcell
@@ -252,30 +251,20 @@ jobs:
                   BBL_AWS_ASSUME_ROLE: ((bosh-dns-release-bbl-test-stress_assume_aws_access_key.role_arn))
                   BBL_AWS_REGION: us-west-1
                   BBL_IAAS: aws
-                  ENV_NAME: windows2019
-                ensure:
-                  put: envs
-                  params:
-                    repository: envs
-                    rebase: true
               - task: setup-deploy
                 file: bosh-dns-release/ci/tasks/windows/setup-deploy.yml
-                params:
-                  ENV_NAME: windows2019
               - in_parallel:
                   - task: windows
                     file: bosh-dns-release/ci/tasks/windows/test-acceptance-windows.yml
                     image: bosh-integration-image
                     params:
                       WINDOWS_OS_VERSION: windows2019
-                      ENV_NAME: windows2019
                     timeout: 1h
                   - task: windows-nameserver-disabled
                     file: bosh-dns-release/ci/tasks/windows/test-acceptance-windows-nameserver-disabled.yml
                     image: bosh-integration-image
                     params:
                       WINDOWS_OS_VERSION: windows2019
-                      ENV_NAME: windows2019
                     timeout: 1h
             ensure:
               task: bbl-destroy
@@ -286,12 +275,6 @@ jobs:
                 BBL_AWS_ASSUME_ROLE: ((bosh-dns-release-bbl-test-stress_assume_aws_access_key.role_arn))
                 BBL_AWS_REGION: us-west-1
                 BBL_IAAS: aws
-                ENV_NAME: windows2019
-              ensure:
-                put: envs
-                params:
-                  repository: envs
-                  rebase: true
 
   - name: test-stress
     public: false
@@ -301,8 +284,6 @@ jobs:
         - get: bosh-dns-release
           trigger: true
           passed: [ pre-integration-fan-in ]
-        - get: bbl-state
-          resource: envs
         - get: bosh-deployment
         - get: docker-release
         - get: aws-jammy-stemcell
@@ -321,41 +302,23 @@ jobs:
               BBL_AWS_ASSUME_ROLE: ((bosh-dns-release-bbl-test-stress_assume_aws_access_key.role_arn))
               BBL_AWS_REGION: us-west-1
               BBL_IAAS: aws
-              BBL_STATE_DIR: test-stress/bbl-state
-            ensure:
-              put: envs
-              params:
-                repository: updated-bbl-state
-                rebase: true
           - task: deploy-docker-vms
             file: bosh-dns-release/ci/tasks/test-stress/deploy-docker.yml
             input_mapping:
-              bbl-state: updated-bbl-state
               stemcell: aws-jammy-stemcell
           - task: deploy-containers
             file: bosh-dns-release/ci/tasks/test-stress/deploy-n.yml
             input_mapping:
               stemcell: warden-jammy-stemcell
-              bbl-state: updated-bbl-state
           - task: stress-containers
             file: bosh-dns-release/ci/tasks/test-stress/run-errand.yml
-            input_mapping:
-              bbl-state: updated-bbl-state
         ensure:
           task: destroy-env
           file: bosh-dns-release/ci/tasks/test-stress/destroy-env.yml
-          input_mapping:
-            bbl-state: updated-bbl-state
           params:
             BBL_AWS_ACCESS_KEY_ID: ((bosh-dns-release-bbl-test-stress_assume_aws_access_key.username))
             BBL_AWS_SECRET_ACCESS_KEY: ((bosh-dns-release-bbl-test-stress_assume_aws_access_key.password))
             BBL_AWS_ASSUME_ROLE: ((bosh-dns-release-bbl-test-stress_assume_aws_access_key.role_arn))
-            BBL_STATE_DIR: test-stress/bbl-state
-          ensure:
-            put: envs
-            params:
-              repository: cleanup-bbl-state
-              rebase: true
 
   - name: brats-ubuntu-jammy
     serial: true
@@ -671,14 +634,6 @@ resources:
       bucket: bosh-director-oss-ci-candidate-release-tarballs
       json_key: ((bosh_director_oss_ci_service_account_json))
       versioned_file: "bosh-dev-release.tgz"
-
-  - name: envs
-    type: git
-    source:
-      branch: master
-      uri: https://github.com/cloudfoundry/bosh-bbl-ci-envs.git
-      username: bosh-admin-bot
-      password: ((github_read_write_token))
 
   - name: release-notes
     type: gcs-resource

--- a/ci/tasks/test-stress/deploy-docker.sh
+++ b/ci/tasks/test-stress/deploy-docker.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-main() {
-  source $PWD/bosh-dns-release/ci/assets/utils.sh
+set -eu -o pipefail
 
-  export BBL_STATE_DIR=$PWD/bbl-state/${BBL_STATE_SUBDIRECTORY}
-  source_bbl_env $BBL_STATE_DIR
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
+
+main() {
+  source "$PWD/bosh-dns-release/ci/assets/utils.sh"
+
+  source "${BBL_STATE_DIR}/.envrc"
 
   local bosh_deployment_repo=$PWD/bosh-deployment
   local docker_release=$(echo $PWD/docker-release/*.tgz)

--- a/ci/tasks/test-stress/deploy-docker.yml
+++ b/ci/tasks/test-stress/deploy-docker.yml
@@ -18,7 +18,7 @@ outputs:
   - name: docker-vars
 
 params:
-  BBL_STATE_SUBDIRECTORY: test-stress/bbl-state
+  CI_BBL_STATE: bbl-state
 
 run:
   path: bosh-dns-release/ci/tasks/test-stress/deploy-docker.sh

--- a/ci/tasks/test-stress/deploy-n.sh
+++ b/ci/tasks/test-stress/deploy-n.sh
@@ -1,9 +1,12 @@
 #!/bin/bash
-main() {
-  source $PWD/bosh-dns-release/ci/assets/utils.sh
+set -eu -o pipefail
 
-  export BBL_STATE_DIR=$PWD/bbl-state/${BBL_STATE_SUBDIRECTORY}
-  source_bbl_env $BBL_STATE_DIR
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
+
+main() {
+  source "$PWD/bosh-dns-release/ci/assets/utils.sh"
+
+  source "${BBL_STATE_DIR}/.envrc"
 
   local state_dir=$PWD/docker-vars
   local stemcell_path=$PWD/stemcell/*.tgz

--- a/ci/tasks/test-stress/deploy-n.yml
+++ b/ci/tasks/test-stress/deploy-n.yml
@@ -13,9 +13,9 @@ inputs:
   - name: stemcell
 
 params:
+  CI_BBL_STATE: bbl-state
   DEPLOYMENTS_OF_100: 10
   PARALLEL_DEPLOYMENTS: 5
-  BBL_STATE_SUBDIRECTORY: test-stress/bbl-state
 
 run:
   path: bosh-dns-release/ci/tasks/test-stress/deploy-n.sh

--- a/ci/tasks/test-stress/destroy-env.sh
+++ b/ci/tasks/test-stress/destroy-env.sh
@@ -1,21 +1,21 @@
 #!/bin/bash
+set -eu -o pipefail
+
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
+
 main() {
-  source $PWD/bosh-dns-release/ci/assets/utils.sh
-  local output_dir="$PWD/cleanup-bbl-state/"
-  local bbl_state_env_repo_dir=$PWD/bbl-state
-  trap "commit_bbl_state_dir ${bbl_state_env_repo_dir} ${BBL_STATE_DIR} ${output_dir} 'Remove bbl state dir'" EXIT
+  source "$PWD/bosh-dns-release/ci/assets/utils.sh"
 
-  (
-    if source_bbl_env bbl-state/${BBL_STATE_DIR} && bosh env; then
-      clean_up_director docker
-    fi
-  )
+  cd "${BBL_STATE_DIR}"
 
-  pushd "bbl-state/${BBL_STATE_DIR}"
-    bbl version
+  bbl version
 
-    bbl --debug destroy --no-confirm
-  popd
+  eval "$(bbl print-env)" || echo "error running 'bbl print-env'"
+  if ! clean_up_director docker; then
+    echo "Failed to cleanup director"
+  fi
+
+  bbl --debug destroy --no-confirm
 }
 
 main

--- a/ci/tasks/test-stress/destroy-env.yml
+++ b/ci/tasks/test-stress/destroy-env.yml
@@ -10,14 +10,11 @@ inputs:
   - name: bbl-state
   - name: bosh-dns-release
 
-outputs:
-  - name: cleanup-bbl-state
-
 params:
+  CI_BBL_STATE: bbl-state
   BBL_AWS_ACCESS_KEY_ID: ""
   BBL_AWS_SECRET_ACCESS_KEY: ""
   BBL_AWS_ASSUME_ROLE: ""
-  BBL_STATE_DIR: test-stress/bbl-state
 
 run:
   path: bosh-dns-release/ci/tasks/test-stress/destroy-env.sh

--- a/ci/tasks/test-stress/run-errand.sh
+++ b/ci/tasks/test-stress/run-errand.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
+set -eu -o pipefail
+
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
+
 main() {
-  source $PWD/bosh-dns-release/ci/assets/utils.sh
+  source "${BBL_STATE_DIR}/.envrc"
 
-  export BBL_STATE_DIR=$PWD/bbl-state/${BBL_STATE_SUBDIRECTORY}
-  source_bbl_env $BBL_STATE_DIR
-
-  pushd bosh-dns-release/ci/assets/test-stress/bosh-workspace
-    # Run test
-    seq 1 "${DEPLOYMENTS_OF_100}" \
-      | xargs -n1 -P"${PARALLEL_DEPLOYMENTS}" -I{} \
-      -- bosh -d bosh-dns-{} run-errand dns-lookuper
-  popd
+  cd bosh-dns-release/ci/assets/test-stress/bosh-workspace
+  # Run test
+  seq 1 "${DEPLOYMENTS_OF_100}" \
+    | xargs -n1 -P"${PARALLEL_DEPLOYMENTS}" -I{} \
+    -- bosh -d bosh-dns-{} run-errand dns-lookuper
 }
 
 main

--- a/ci/tasks/test-stress/run-errand.yml
+++ b/ci/tasks/test-stress/run-errand.yml
@@ -11,9 +11,9 @@ inputs:
   - name: bosh-dns-release
 
 params:
+  CI_BBL_STATE: bbl-state
   DEPLOYMENTS_OF_100: 10
   PARALLEL_DEPLOYMENTS: 10
-  BBL_STATE_SUBDIRECTORY: test-stress/bbl-state
 
 run:
   path: bosh-dns-release/ci/tasks/test-stress/run-errand.sh

--- a/ci/tasks/test-stress/setup-env.sh
+++ b/ci/tasks/test-stress/setup-env.sh
@@ -1,33 +1,33 @@
 #!/bin/bash
+set -eu -o pipefail
+
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
+
 main() {
-  source $PWD/bosh-dns-release/ci/assets/utils.sh
-  local output_dir="$PWD/updated-bbl-state/"
-  local bbl_state_env_repo_dir=$PWD/bbl-state
-  trap "commit_bbl_state_dir ${bbl_state_env_repo_dir} ${BBL_STATE_DIR} ${output_dir} 'Update bbl state dir'" EXIT
+  source "$PWD/bosh-dns-release/ci/assets/utils.sh"
 
   export TEST_STRESS_ASSETS=$PWD/bosh-dns-release/ci/assets/test-stress
-  export BOSH_DOCKER_CPI_RELEASE_TARBALL="$( echo $PWD/bosh-docker-cpi-release/*.tgz )"
+  export BOSH_DOCKER_CPI_RELEASE_TARBALL="$( echo "$PWD"/bosh-docker-cpi-release/*.tgz )"
   export BOSH_LOG_LEVEL="${BOSH_LOG_LEVEL:-}"
 
-  mkdir -p bbl-state/${BBL_STATE_DIR}
+  mkdir -p "${BBL_STATE_DIR}"
+  cd "${BBL_STATE_DIR}"
 
-  pushd bbl-state/${BBL_STATE_DIR}
-    bbl version
-    bbl plan > bbl_plan.txt
+  bbl version
+  bbl plan > bbl_plan.txt
 
-    # Customize environment
-    cp $TEST_STRESS_ASSETS/terraform/* terraform/
-    cp $TEST_STRESS_ASSETS/director/*.sh .
+  # Customize environment
+  cp "$TEST_STRESS_ASSETS"/terraform/* terraform/
+  cp "$TEST_STRESS_ASSETS"/director/*.sh .
 
-    bbl --debug up
+  bbl --debug up
+  bbl print-env > .envrc
+  source .envrc
 
-    eval "$(bbl print-env)"
-
-    # Need to delete the bosh-dns runtime config because bbl uses a hard-coded
-    # bosh-deployment which specifies a bosh-dns version that may conflict with the
-    # one we are trying to test.
-    bosh delete-config --type=runtime --name=dns -n
-  popd
+  # Need to delete the bosh-dns runtime config because bbl uses a hard-coded
+  # bosh-deployment which specifies a bosh-dns version that may conflict with the
+  # one we are trying to test.
+  bosh delete-config --type=runtime --name=dns -n
 }
 
 main

--- a/ci/tasks/test-stress/setup-env.yml
+++ b/ci/tasks/test-stress/setup-env.yml
@@ -7,20 +7,19 @@ image_resource:
     repository: cloudfoundry/cf-deployment-concourse-tasks
 
 inputs:
-  - name: bbl-state
   - name: bosh-dns-release
   - name: bosh-docker-cpi-release
 
 outputs:
-  - name: updated-bbl-state
+  - name: bbl-state
 
 params:
+  CI_BBL_STATE: bbl-state
   BBL_AWS_ACCESS_KEY_ID: ""
   BBL_AWS_SECRET_ACCESS_KEY: ""
   BBL_AWS_ASSUME_ROLE: ""
   BBL_AWS_REGION: us-west-2
   BBL_IAAS: aws
-  BBL_STATE_DIR: test-stress/bbl-state
   BOSH_LOG_LEVEL:
 
 run:

--- a/ci/tasks/windows/bbl-destroy.sh
+++ b/ci/tasks/windows/bbl-destroy.sh
@@ -1,25 +1,21 @@
 #!/bin/bash
+set -eu -o pipefail
 
-set -e
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
 
 main() {
   source "$PWD/bosh-dns-release/ci/assets/utils.sh"
-  local output_dir="$PWD/envs-output/"
-  local bbl_state_env_repo_dir=$PWD/envs
-  trap "commit_bbl_state_dir ${bbl_state_env_repo_dir} ${ENV_NAME} ${output_dir} 'Remove bbl state dir'" EXIT
 
-  (
-    source_bbl_env "envs/${ENV_NAME}"
-    clean_up_director
-  )
+  cd "${BBL_STATE_DIR}"
 
-  (
-    cd "envs/${ENV_NAME}"
+  bbl version
 
-    bbl version
+  eval "$(bbl print-env)" || echo "error running 'bbl print-env'"
+  if ! clean_up_director; then
+    echo "Failed to cleanup director"
+  fi
 
-    bbl --debug destroy --no-confirm
-  )
+  bbl --debug destroy --no-confirm
 }
 
 main

--- a/ci/tasks/windows/bbl-destroy.yml
+++ b/ci/tasks/windows/bbl-destroy.yml
@@ -7,15 +7,11 @@ image_resource:
     repository: cloudfoundry/cf-deployment-concourse-tasks
 
 inputs:
+  - name: bbl-state
   - name: bosh-dns-release
-  - name: envs
-
-outputs:
-  - name: envs
-    path: envs-output
 
 params:
-  ENV_NAME:
+  CI_BBL_STATE: bbl-state
   BBL_IAAS:
   BBL_AWS_ACCESS_KEY_ID:
   BBL_AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/windows/bbl-up.sh
+++ b/ci/tasks/windows/bbl-up.sh
@@ -1,32 +1,27 @@
 #!/bin/bash
+set -eu -o pipefail
+
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
+
 main() {
-  source $PWD/bosh-dns-release/ci/assets/utils.sh
-  local output_dir="$PWD/envs-output/"
-  local bbl_state_env_repo_dir=$PWD/envs
-  trap "commit_bbl_state_dir ${bbl_state_env_repo_dir} ${ENV_NAME} ${output_dir} 'Update bbl state dir'" EXIT
+  source "$PWD/bosh-dns-release/ci/assets/utils.sh"
 
-  mkdir -p envs/${ENV_NAME}
-  local bosh_release_path=$(echo $PWD/bosh-candidate-release/*.tgz)
+  local bosh_release_path=$(echo "$PWD"/bosh-candidate-release/*.tgz)
 
-  pushd envs/${ENV_NAME}
-    bbl version
-    bbl plan > bbl_plan.txt
-    # Use the local bosh release
-    sed -i "/bosh create-env/a -o \${BBL_STATE_DIR}/bosh-deployment/local-bosh-release-tarball.yml -v local_bosh_release=${bosh_release_path} \\\\" create-director.sh
-    # Remove the iam profile ops file - doesn't work with our assume role setup
-    sed -i "/iam-instance-profile/d" create-director.sh
-    bbl --debug up
-    bbl print-env > .envrc
-    source .envrc
-    cp "${JUMPBOX_PRIVATE_KEY}" bosh_jumpbox_private.key
+  mkdir -p "${BBL_STATE_DIR}"
+  cd "${BBL_STATE_DIR}"
 
-    sed -i '/JUMPBOX_PRIVATE_KEY\|BOSH_ALL_PROXY\|CREDHUB_PROXY/d' .envrc
+  bbl version
+  bbl plan > bbl_plan.txt
 
-    echo "export JUMPBOX_ADDRESS=$(bbl jumpbox-address):22" >> .envrc
-    echo 'export JUMPBOX_PRIVATE_KEY=$PWD/bosh_jumpbox_private.key' >> .envrc
-    echo "export BOSH_ALL_PROXY=\"ssh+socks5://jumpbox@$(bbl jumpbox-address):22?private-key=\$JUMPBOX_PRIVATE_KEY\"" >> .envrc
-    echo 'export CREDHUB_PROXY="${BOSH_ALL_PROXY}"' >> .envrc
-  popd
+  # Use the local bosh release
+  sed -i "/bosh create-env/a -o \${BBL_STATE_DIR}/bosh-deployment/local-bosh-release-tarball.yml -v local_bosh_release=${bosh_release_path} \\\\" create-director.sh
+  # Remove the iam profile ops file - doesn't work with our assume role setup
+  sed -i "/iam-instance-profile/d" create-director.sh
+
+  bbl --debug up
+  bbl print-env > .envrc
+  source .envrc
 }
 
 main

--- a/ci/tasks/windows/bbl-up.yml
+++ b/ci/tasks/windows/bbl-up.yml
@@ -8,15 +8,13 @@ image_resource:
 
 inputs:
   - name: bosh-dns-release
-  - name: envs
   - name: bosh-candidate-release
 
 outputs:
-  - name: envs
-    path: envs-output
+  - name: bbl-state
 
 params:
-  ENV_NAME:
+  CI_BBL_STATE: bbl-state
   BBL_IAAS:
   BBL_AWS_ACCESS_KEY_ID:
   BBL_AWS_SECRET_ACCESS_KEY:

--- a/ci/tasks/windows/setup-deploy.sh
+++ b/ci/tasks/windows/setup-deploy.sh
@@ -1,14 +1,12 @@
-#!/bin/bash -lx
-
+#!/bin/bash
 set -eu -o pipefail
+
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
 
 main() {
   ROOT_DIR=$PWD
-  BBL_STATE_DIR=$ROOT_DIR/envs/$ENV_NAME
 
-  pushd $BBL_STATE_DIR
-    source .envrc
-  popd
+  source "${BBL_STATE_DIR}/.envrc"
 
   env
 

--- a/ci/tasks/windows/setup-deploy.yml
+++ b/ci/tasks/windows/setup-deploy.yml
@@ -8,13 +8,13 @@ image_resource:
 
 inputs:
   - name: bosh-dns-release
-  - name: envs
+  - name: bbl-state
   - name: bosh-stemcell-windows
   - name: linux-stemcell
   - name: candidate-release
 
 params:
-  ENV_NAME:
+  CI_BBL_STATE: bbl-state
 
 run:
   path: bosh-dns-release/ci/tasks/windows/setup-deploy.sh

--- a/ci/tasks/windows/test-acceptance-windows-nameserver-disabled.sh
+++ b/ci/tasks/windows/test-acceptance-windows-nameserver-disabled.sh
@@ -1,21 +1,19 @@
-#!/bin/bash -eux
-
+#!/bin/bash
 set -eu -o pipefail
 
-ROOT_DIR=$PWD
-BBL_STATE_DIR=$ROOT_DIR/envs/$ENV_NAME
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
 
-pushd $BBL_STATE_DIR
-  source .envrc
-popd
+ROOT_DIR=$PWD
+
+source "${BBL_STATE_DIR}/.envrc"
 
 export BOSH_DEPLOYMENT=bosh-dns-windows-acceptance-nameserver-disabled
 
 bosh -n deploy \
-  $ROOT_DIR/bosh-dns-release/src/bosh-dns/test_yml_assets/manifests/windows-acceptance-manifest.yml \
+  "$ROOT_DIR/bosh-dns-release/src/bosh-dns/test_yml_assets/manifests/windows-acceptance-manifest.yml" \
   -v deployment_name="$BOSH_DEPLOYMENT" \
-  -v windows_stemcell=$WINDOWS_OS_VERSION \
+  -v windows_stemcell="$WINDOWS_OS_VERSION" \
   --vars-store dns-creds.yml \
-  -o $ROOT_DIR/bosh-dns-release/src/bosh-dns/acceptance_tests/windows/disable_nameserver_override/manifest-ops.yml
+  -o "$ROOT_DIR/bosh-dns-release/src/bosh-dns/acceptance_tests/windows/disable_nameserver_override/manifest-ops.yml"
 
 bosh run-errand acceptance-tests-windows

--- a/ci/tasks/windows/test-acceptance-windows-nameserver-disabled.yml
+++ b/ci/tasks/windows/test-acceptance-windows-nameserver-disabled.yml
@@ -2,12 +2,12 @@
 platform: linux
 
 inputs:
+  - name: bbl-state
   - name: bosh-dns-release
-  - name: envs
 
 run:
   path: bosh-dns-release/ci/tasks/windows/test-acceptance-windows-nameserver-disabled.sh
 
 params:
-  ENV_NAME: ""
-  WINDOWS_OS_VERSION: ""
+  CI_BBL_STATE: bbl-state
+  WINDOWS_OS_VERSION:

--- a/ci/tasks/windows/test-acceptance-windows.sh
+++ b/ci/tasks/windows/test-acceptance-windows.sh
@@ -1,22 +1,20 @@
-#!/bin/bash -eux
-
+#!/bin/bash
 set -eu -o pipefail
 
-ROOT_DIR=$PWD
-BBL_STATE_DIR=$ROOT_DIR/envs/$ENV_NAME
+BBL_STATE_DIR="${PWD}/${CI_BBL_STATE}"
 
-pushd "${BBL_STATE_DIR}"
-  source .envrc
-popd
+ROOT_DIR=$PWD
+
+source "${BBL_STATE_DIR}/.envrc"
 
 export BOSH_DEPLOYMENT=bosh-dns-windows-acceptance
 
 bosh -n deploy \
-  $ROOT_DIR/bosh-dns-release/src/bosh-dns/test_yml_assets/manifests/windows-acceptance-manifest.yml \
+  "$ROOT_DIR/bosh-dns-release/src/bosh-dns/test_yml_assets/manifests/windows-acceptance-manifest.yml" \
   -v deployment_name="$BOSH_DEPLOYMENT" \
-  -v windows_stemcell=$WINDOWS_OS_VERSION \
+  -v windows_stemcell="$WINDOWS_OS_VERSION" \
   --vars-store dns-creds.yml \
-  -o $ROOT_DIR/bosh-dns-release/src/bosh-dns/test_yml_assets/ops/manifest/enable-health-manifest-windows.yml \
+  -o "$ROOT_DIR/bosh-dns-release/src/bosh-dns/test_yml_assets/ops/manifest/enable-health-manifest-windows.yml" \
   -v health_server_port=2345
 
 bosh run-errand acceptance-tests-windows

--- a/ci/tasks/windows/test-acceptance-windows.yml
+++ b/ci/tasks/windows/test-acceptance-windows.yml
@@ -2,12 +2,12 @@
 platform: linux
 
 inputs:
+  - name: bbl-state
   - name: bosh-dns-release
-  - name: envs
 
 run:
   path: bosh-dns-release/ci/tasks/windows/test-acceptance-windows.sh
 
 params:
-  ENV_NAME: ""
-  WINDOWS_OS_VERSION: ""
+  CI_BBL_STATE: bbl-state
+  WINDOWS_OS_VERSION:

--- a/docs/WindowsDevReadme.txt
+++ b/docs/WindowsDevReadme.txt
@@ -4,4 +4,4 @@ bin/test-acceptance-windows.sh` code will never hit the bbl-destroy). After the 
 the fly container that launched the bosh director that was used to deploy the windows tests, and then use the
 `bosh deploy` commands in test-acceptance-windows.sh to redeploy your Windows boxen.
 
-Need to delete `bbl-state/creds.yml` in between runs to re-generate BOSH director CA cert for new IP addresses
+Need to delete `$BBL_STATE_DIR/creds.yml` in between runs to re-generate BOSH director CA cert for new IP addresses


### PR DESCRIPTION
The state is only ever used within a single Concourse job which allows the state to be passed as input/output witout needing to persist this to a github repo[1]

[1] https://github.com/cloudfoundry/bosh-bbl-ci-envs