### PR TITLE
 CI: fix env file path for docker-cpi image from ghcr.io

### DIFF
--- a/ci/tasks/test-acceptance.sh
+++ b/ci/tasks/test-acceptance.sh
@@ -10,7 +10,7 @@ source start-bosh \
     -v local_bosh_release="$(echo -n "$PWD"/bosh-candidate-release/*.tgz)"
 
 # shellcheck disable=SC1091
-source /tmp/local-bosh/director/env
+source /tmp/local-bosh/director/bosh-env
 
 bosh int /tmp/local-bosh/director/creds.yml --path /jumpbox_ssh/private_key > /tmp/jumpbox_ssh_key.pem
 chmod 400 /tmp/jumpbox_ssh_key.pem


### PR DESCRIPTION
The ghcr.io docker-cpi image ships a start-bosh that writes the BOSH environment to bosh-env, not env. Update the source path to match.