### PR TITLE
CI: Use official docker cpi repo

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -603,7 +603,7 @@ resources:
   - name: bosh-docker-cpi-release
     type: bosh-io-release
     source:
-      repository: cppforlife/bosh-docker-cpi-release
+      repository: cloudfoundry/bosh-docker-cpi-release
 
   - name: aws-windows-2019-stemcell
     type: bosh-io-stemcell


### PR DESCRIPTION
The test-stress has been using cppforlife, should be cloudfoundry