### PR TITLE
CI: Update docker API version

### DIFF
--- a/ci/assets/test-stress/bosh-workspace/cpi-config.yml
+++ b/ci/assets/test-stress/bosh-workspace/cpi-config.yml
@@ -10,67 +10,67 @@ cpis:
   properties:
     host: tcp://((docker_server_ip_0)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-2
   type: docker
   properties:
     host: tcp://((docker_server_ip_1)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-3
   type: docker
   properties:
     host: tcp://((docker_server_ip_2)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-4
   type: docker
   properties:
     host: tcp://((docker_server_ip_3)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-5
   type: docker
   properties:
     host: tcp://((docker_server_ip_4)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-6
   type: docker
   properties:
     host: tcp://((docker_server_ip_5)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-7
   type: docker
   properties:
     host: tcp://((docker_server_ip_6)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-8
   type: docker
   properties:
     host: tcp://((docker_server_ip_7)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-9
   type: docker
   properties:
     host: tcp://((docker_server_ip_8)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"
 
 - name: docker-10
   type: docker
   properties:
     host: tcp://((docker_server_ip_9)):4243
     tls: ((docker_client_tls))
-    api_version: "1.22"
+    api_version: "1.41"


### PR DESCRIPTION
Switching to the latest bosh-docker-cpi-release requires a new API version.

Should resolve:
```
 L Error: CPI error 'Bosh::Clouds::CloudError' with message 'Creating VM with agent ID '{{50497690-5c60-4049-9995-7ac6559e2a63}}': Creating container: "specify container image platform" requires API version 1.41, but the Docker daemon API version is 1.22' in 'create_vm' CPI method (CPI request ID: 'cpi-785210')
```