### PR TITLE
CI: Use jammy overrides for jammy BRATs

### DIFF
--- a/ci/ops/brats-jammy-dns-overrides.yml
+++ b/ci/ops/brats-jammy-dns-overrides.yml
@@ -1,0 +1,13 @@
+# On Jammy, bosh-dns binds directly to 169.254.0.2:53 via a loopback alias,
+# overrides /etc/resolv.conf, and forwards non-.bosh queries to upstream recursors.
+# The three properties below are Noble-specific (set in dns-with-templates-manifest.yml
+# as part of Noble support) and must be reverted to their Jammy defaults.
+- path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/configure_systemd_resolved
+  type: replace
+  value: false
+- path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/override_nameserver
+  type: replace
+  value: true
+- path: /addons/name=bosh-dns/jobs/name=bosh-dns/properties/disable_recursors
+  type: replace
+  value: false

--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -365,6 +365,7 @@ jobs:
           DIRECTOR_STEMCELL_OS: ubuntu-jammy
           STEMCELL_OS: ubuntu-jammy
           ADDITIONAL_DIRECTOR_OPS_FILES: "-o bosh-ci/ci/dockerfiles/docker-cpi/gcp-internal-dns-ops.yml"
+          BRATS_DNS_MANIFEST_OPS_FILES: "-o bosh-dns-release/ci/ops/brats-jammy-dns-overrides.yml"
 
   - name: brats-ubuntu-noble
     serial: true


### PR DESCRIPTION
The BRATs have been hardcoded for noble, and we need to override some values back to jammy settings for that test job.
