### PR TITLE
CI: Fix test-recursor to work with Noble

### DIFF
--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/jobs/test-recursor/templates/config.yml.erb
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/jobs/test-recursor/templates/config.yml.erb
@@ -1,3 +1,4 @@
 ---
 port: <%= p('port') %>
 configurable_response: <%= p('configurable_response') %>
+address: <%= spec.ip %>

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/config/config.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/config/config.go
@@ -7,6 +7,7 @@ import (
 )
 
 type Config struct {
+	Address              string `yaml:"address"`
 	Port                 int    `yaml:"port"`
 	ConfigurableResponse string `yaml:"configurable_response"`
 }

--- a/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/main/test-recursor.go
+++ b/src/bosh-dns/acceptance_tests/dns-acceptance-release/src/test-recursor/main/test-recursor.go
@@ -19,7 +19,10 @@ func main() {
 
 	cfg := loadConfig(os.Args[1])
 
-	server := &dns.Server{Addr: fmt.Sprintf("0.0.0.0:%d", cfg.Port), Net: "udp", UDPSize: 65535}
+	if cfg.Address == "" {
+		cfg.Address = "0.0.0.0"
+	}
+	server := &dns.Server{Addr: fmt.Sprintf("%s:%d", cfg.Address, cfg.Port), Net: "udp", UDPSize: 65535}
 	nextAddress := 0
 
 	dns.HandleFunc("truncated-recursor.com.", func(resp dns.ResponseWriter, req *dns.Msg) {


### PR DESCRIPTION
We can't bind the test-recursor to 0.0.0.0:53 on noble, since that's where systemd-resolved is bound.  Instead, bind to the spec.ip address.