### PR TITLE
Replace chpst with setpriv in bosh-dns job scripts

### DIFF
--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -81,7 +81,7 @@ function start_dns() {
 
   pushd ${JOB_DIR}
 
-  chpst -u vcap:vcap \
+  setpriv --reuid=vcap --regid=vcap --clear-groups -- \
     "${DNS_PACKAGE}/bin/bosh-dns" \
     --config "${JOB_DIR}/config/config.json" \
     1>> ${LOG_DIR}/bosh_dns.stdout.log \

--- a/jobs/bosh-dns/templates/bosh_dns_health_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_health_ctl.erb
@@ -48,7 +48,8 @@ function start_process() {
   ulimit -v unlimited
   ulimit -n 4096
 
-  exec chpst -u vcap:vcap "${DNS_PACKAGE}/bin/bosh-dns-health" \
+  setpriv --reuid=vcap --regid=vcap --clear-groups --no-new-privs -- \
+    "${DNS_PACKAGE}/bin/bosh-dns-health" \
     config/health_server_config.json \
     1>> ${LOG_DIR}/bosh_dns_health.stdout.log \
     2>> ${LOG_DIR}/bosh_dns_health.stderr.log &

--- a/spec/jobs/bosh-dns_spec.rb
+++ b/spec/jobs/bosh-dns_spec.rb
@@ -6,4 +6,34 @@ describe 'bosh-dns' do
 
   it_behaves_like 'common config.json'
 
+  describe 'bin/bosh_dns_ctl' do
+    let(:template) { job.template('bin/bosh_dns_ctl') }
+    let(:rendered) { template.render({}) }
+
+    it 'does not reference chpst' do
+      expect(rendered).not_to include('chpst')
+    end
+
+    it 'uses setpriv to drop privileges to vcap' do
+      expect(rendered).to include('setpriv --reuid=vcap --regid=vcap --clear-groups --')
+    end
+
+    it 'does not use --no-new-privs because bosh-dns relies on cap_net_bind_service file capability for port 53' do
+      expect(rendered).not_to include('--no-new-privs')
+    end
+  end
+
+  describe 'bin/bosh_dns_health_ctl' do
+    let(:template) { job.template('bin/bosh_dns_health_ctl') }
+    let(:rendered) { template.render({}) }
+
+    it 'does not reference chpst' do
+      expect(rendered).not_to include('chpst')
+    end
+
+    it 'uses setpriv with --no-new-privs to drop privileges to vcap' do
+      expect(rendered).to include('setpriv --reuid=vcap --regid=vcap --clear-groups --no-new-privs --')
+    end
+  end
+
 end


### PR DESCRIPTION
The runit package (which provides chpst) is removed from the Resolute Raccoon stemcell. Replace chpst -u vcap:vcap with setpriv --reuid=vcap --regid=vcap --clear-groups -- in both bosh_dns_ctl and bosh_dns_health_ctl, consistent with the pattern used in bat-release.