### PR TITLE
fix noble acceptance tests

### DIFF
--- a/ci/tasks/test-acceptance.yml
+++ b/ci/tasks/test-acceptance.yml
@@ -8,7 +8,7 @@ inputs:
   - name: bosh-candidate-release
 
 params:
-  BASE_STEMCELL: ubuntu-bionic
+  BASE_STEMCELL: ubuntu-jammy
 
 run:
   path: bosh-dns-release/ci/tasks/test-acceptance.sh

--- a/scripts/run-acceptance-tests
+++ b/scripts/run-acceptance-tests
@@ -13,7 +13,7 @@ export TEST_MANIFEST_NAME="manifest"
 export NO_RECURSORS_OPS_FILE="no-recursors-configured"
 export LOCAL_RECURSOR_OPS_FILE="add-test-dns-nameservers"
 export TEST_TARGET_OS="linux"
-export BASE_STEMCELL="${BASE_STEMCELL:-ubuntu-bionic}"
+export BASE_STEMCELL="${BASE_STEMCELL:-ubuntu-jammy}"
 
 go_bin_path="$(go env GOPATH)/bin" # TODO this should be handled in the docker container
 export PATH=${go_bin_path}:${PATH}
@@ -44,11 +44,18 @@ popd
 # one we are trying to test.
 bosh delete-config --type=runtime --name=dns -n
 
+DEPLOY_OPS="-o ./src/bosh-dns/test_yml_assets/ops/manifest/enable-health-manifest-linux.yml"
+DEPLOY_OPS="${DEPLOY_OPS} -o ./src/bosh-dns/test_yml_assets/ops/manifest/enable-require-dns-in-pre-start-ops.yml"
+
+# TODO: remove when Jammy goes EOL
+if [[ "${BASE_STEMCELL}" == "ubuntu-jammy" ]]; then
+  DEPLOY_OPS="${DEPLOY_OPS} -o ./src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml"
+fi
+
+# shellcheck disable=SC2086
 bosh -n deploy ./src/bosh-dns/test_yml_assets/manifests/dns-linux.yml \
   -v health_server_port=2345 \
-  -o ./src/bosh-dns/test_yml_assets/ops/manifest/use-dns-release-default-bind-and-alias-addresses.yml \
-  -o ./src/bosh-dns/test_yml_assets/ops/manifest/enable-health-manifest-linux.yml \
-  -o ./src/bosh-dns/test_yml_assets/ops/manifest/enable-require-dns-in-pre-start-ops.yml \
+  ${DEPLOY_OPS} \
   -v base_stemcell="${BASE_STEMCELL}" \
   --vars-store dns-creds.yml
 

--- a/scripts/test-acceptance
+++ b/scripts/test-acceptance
@@ -15,7 +15,7 @@ fly -t production workers || fly -t production login
 
 fly -t production execute --privileged \
   --config=./ci/tasks/test-acceptance.yml \
-  --inputs-from=bosh-dns-release/test-acceptance-ubuntu-bionic \
+  --inputs-from=bosh-dns-release/test-acceptance-ubuntu-jammy \
   --input=candidate-release="${tarball_dir}" \
   --input=bosh-dns-release="${REPO_DIR}/../" \
   "$@"

--- a/src/bosh-dns/acceptance_tests/helpers/settings.go
+++ b/src/bosh-dns/acceptance_tests/helpers/settings.go
@@ -1,0 +1,16 @@
+package helpers
+
+// OverrideNameserverFor reports whether bosh-dns should manage /etc/resolv.conf
+// for the given stemcell OS, mirroring the override_nameserver release property.
+func OverrideNameserverFor(stemcell string) bool {
+	// TODO: remove when Jammy goes EOL
+	return stemcell == "ubuntu-jammy"
+}
+
+// ConfigureSystemdResolvedFor reports whether bosh-dns should configure
+// systemd-resolved for the given stemcell OS, mirroring the
+// configure_systemd_resolved release property.
+func ConfigureSystemdResolvedFor(stemcell string) bool {
+	// TODO: remove when Jammy goes EOL
+	return stemcell != "ubuntu-jammy"
+}

--- a/src/bosh-dns/acceptance_tests/init_test.go
+++ b/src/bosh-dns/acceptance_tests/init_test.go
@@ -33,7 +33,6 @@ var _ = BeforeSuite(func() {
 	testTargetOS = assertEnvExists("TEST_TARGET_OS")
 	baseStemcell = assertEnvExists("BASE_STEMCELL")
 	boshDeployment = assertEnvExists("BOSH_DEPLOYMENT")
-
 	deployTestRecursors()
 	deployTestHTTPDNSServer()
 
@@ -111,4 +110,12 @@ func setupLocalRecursorOpsFile() string {
 	}
 
 	return "ops/cloud-config/add-test-dns-nameservers.yml"
+}
+
+func stemcellDNSOpsFile() string {
+	if helpers.OverrideNameserverFor(baseStemcell) {
+		// TODO: remove when Jammy goes EOL
+		return "ops/manifest/override-nameserver-dns-settings.yml"
+	}
+	return ""
 }

--- a/src/bosh-dns/acceptance_tests/linux/init_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/init_test.go
@@ -25,6 +25,7 @@ var (
 	boshBinaryPath       string
 	allDeployedInstances []instanceInfo
 	firstInstanceSlug    string
+	baseStemcell         string
 )
 
 var _ = BeforeSuite(func() {
@@ -34,6 +35,7 @@ var _ = BeforeSuite(func() {
 	assertEnvExists("BOSH_CA_CERT")
 	assertEnvExists("BOSH_ENVIRONMENT")
 	assertEnvExists("BOSH_DEPLOYMENT")
+	baseStemcell = assertEnvExists("BASE_STEMCELL")
 
 	allDeployedInstances = getInstanceInfos(boshBinaryPath)
 	firstInstanceSlug = fmt.Sprintf("%s/%s", allDeployedInstances[0].InstanceGroup, allDeployedInstances[0].InstanceID)

--- a/src/bosh-dns/acceptance_tests/linux/linux_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/linux_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"time"
 
+	"bosh-dns/acceptance_tests/helpers"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/gbytes"
@@ -132,6 +134,11 @@ var _ = Describe("Alias address binding", func() {
 
 		Context("external processes changing /etc/resolv.conf", func() {
 			BeforeEach(func() {
+				// TODO: remove when Jammy goes EOL
+				if !helpers.OverrideNameserverFor(baseStemcell) {
+					Skip("bosh-dns-resolvconf is disabled on non-Jammy stemcells; /etc/resolv.conf is managed by systemd-resolved")
+				}
+
 				backup := exec.Command(boshBinaryPath, []string{"ssh", "bosh-dns/0", "-c", "sudo cp `readlink /etc/resolv.conf` /tmp/resolv.conf.backup"}...)
 
 				session, err := gexec.Start(backup, GinkgoWriter, GinkgoWriter)
@@ -140,6 +147,10 @@ var _ = Describe("Alias address binding", func() {
 			})
 
 			AfterEach(func() {
+				// TODO: remove when Jammy goes EOL
+				if !helpers.OverrideNameserverFor(baseStemcell) {
+					return
+				}
 				restore := exec.Command(boshBinaryPath, []string{"ssh", "bosh-dns/0", "-c", "sudo mv /tmp/resolv.conf.backup `readlink /etc/resolv.conf`"}...)
 				session, err := gexec.Start(restore, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())

--- a/src/bosh-dns/acceptance_tests/support_test.go
+++ b/src/bosh-dns/acceptance_tests/support_test.go
@@ -74,15 +74,19 @@ func ensureRecursorIsDefinedByBoshAgent() {
 
 	updateCloudConfigWithOurLocalRecursor()
 
-	helpers.Bosh(
+	args := []string{
 		"deploy",
 		"-v", fmt.Sprintf("name=%s", boshDeployment),
 		"-v", fmt.Sprintf("base_stemcell=%s", baseStemcell),
 		"-o", disableOverridePath,
 		"-o", excludedRecursorsPath,
 		"--vars-store", "creds.yml",
-		manifestPath,
-	)
+	}
+	if ops := stemcellDNSOpsFile(); ops != "" {
+		args = append(args, "-o", assetPath(ops))
+	}
+	args = append(args, manifestPath)
+	helpers.Bosh(args...)
 	allDeployedInstances = helpers.BoshInstances("bosh-dns")
 }
 
@@ -92,7 +96,7 @@ func ensureRecursorIsDefinedByDNSRelease() {
 
 	updateCloudConfigWithDefaultCloudConfig()
 
-	helpers.Bosh(
+	args := []string{
 		"deploy",
 		"-o", configureRecursorPath,
 		"-v", fmt.Sprintf("name=%s", boshDeployment),
@@ -100,8 +104,12 @@ func ensureRecursorIsDefinedByDNSRelease() {
 		"-v", fmt.Sprintf("recursor_a=%s", RecursorIPAddresses[0]),
 		"-v", fmt.Sprintf("recursor_b=%s", RecursorIPAddresses[1]),
 		"--vars-store", "creds.yml",
-		manifestPath,
-	)
+	}
+	if ops := stemcellDNSOpsFile(); ops != "" {
+		args = append(args, "-o", assetPath(ops))
+	}
+	args = append(args, manifestPath)
+	helpers.Bosh(args...)
 	allDeployedInstances = helpers.BoshInstances("bosh-dns")
 }
 
@@ -138,10 +146,13 @@ func ensureHealthEndpointDeployed(extraOps ...string) {
 		"-v", "health_server_port=2345",
 		"-o", assetPath(enableHealthManifestOps()),
 		"--vars-store", "creds.yml",
-		manifestPath,
 	}
 
 	args = append(args, extraOps...)
+	if ops := stemcellDNSOpsFile(); ops != "" {
+		args = append(args, "-o", assetPath(ops))
+	}
+	args = append(args, manifestPath)
 	helpers.Bosh(args...)
 
 	allDeployedInstances = helpers.BoshInstances("bosh-dns")

--- a/src/bosh-dns/test_yml_assets/manifests/dns-linux.yml
+++ b/src/bosh-dns/test_yml_assets/manifests/dns-linux.yml
@@ -30,7 +30,8 @@ instance_groups:
   - name: bosh-dns
     release: bosh-dns
     properties:
-      address: 0.0.0.0
+      configure_systemd_resolved: true
+      override_nameserver: false
       api:
         server:
           tls: ((dns_api_server_tls))

--- a/src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml
+++ b/src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml
@@ -1,0 +1,12 @@
+# TODO: remove when Jammy goes EOL
+- type: replace
+  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/address
+  value: 0.0.0.0
+
+- type: replace
+  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/configure_systemd_resolved
+  value: false
+
+- type: replace
+  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/override_nameserver
+  value: true

--- a/src/bosh-dns/test_yml_assets/ops/manifest/use-dns-release-default-bind-and-alias-addresses.yml
+++ b/src/bosh-dns/test_yml_assets/ops/manifest/use-dns-release-default-bind-and-alias-addresses.yml
@@ -1,2 +1,2 @@
 - type: remove
-  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/address
+  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/address?


### PR DESCRIPTION
The test-acceptance-ubuntu-noble job has never been green. This hopefully will fix it.

Changing the default settings in the build to be a systemd integrated bosh-dns, and applying an ops file on Jammy which can be removed when Jammy goes out of support.