### PR TITLE
Prevent bosh-dns interface from becoming DefaultRoute on noble warden

### DIFF
--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -57,6 +57,7 @@ function create_network_interface() {
     ip addr add <%= p('address') %>/32 dev bosh-dns
     ip link set bosh-dns up
     resolvectl dns bosh-dns <%= p('address') %>
+    resolvectl default-route bosh-dns no
     resolvectl log-level <%= {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'NONE' => 'emerg'}[p('log_level')] %>
   fi
 }

--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -55,11 +55,11 @@ function create_network_interface() {
   then
     ip link add bosh-dns type dummy
     ip addr add <%= p('address') %>/32 dev bosh-dns
-    ip link set bosh-dns up
-    resolvectl dns bosh-dns <%= p('address') %>
-    resolvectl default-route bosh-dns no
-    resolvectl log-level <%= {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'NONE' => 'emerg'}[p('log_level')] %>
   fi
+  ip link set bosh-dns up
+  resolvectl dns bosh-dns <%= p('address') %>
+  resolvectl default-route bosh-dns no
+  resolvectl log-level <%= {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'NONE' => 'emerg'}[p('log_level')] %>
 }
 
 function remove_network_interface() {

--- a/src/bosh-dns/acceptance_tests/linux/linux_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/linux_test.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -128,6 +129,56 @@ var _ = Describe("Alias address binding", func() {
 			Eventually(session, 10*time.Second).Should(gexec.Exit(0))
 			output := string(session.Out.Contents())
 			Expect(output).To(ContainSubstring(";; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0"))
+		})
+
+		Context("when configure_systemd_resolved is enabled (noble stemcell)", func() {
+			// The bosh-dns dummy interface is only created when configure_systemd_resolved=true,
+			// which is set exclusively for ubuntu-noble in the bosh-dns-systemd runtime config addon.
+			// On jammy and earlier, bosh-dns binds to a loopback alias instead — no bosh-dns link exists.
+			hasBoshDnsInterface := func() bool {
+				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
+					"ip link show bosh-dns > /dev/null 2>&1 && echo yes || echo no"}...)
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(session, 10*time.Second).Should(gexec.Exit(0))
+				return strings.Contains(string(session.Out.Contents()), "yes")
+			}
+
+			It("does not set the bosh-dns interface as the default DNS route", func() {
+				// bosh-dns must never hold +DefaultRoute on the bosh-dns dummy interface.
+				// If it does, all external DNS queries are routed to bosh-dns instead of
+				// the IaaS-provided upstream - causing REFUSED on warden containers where
+				// no physical NIC has DHCP DNS to serve as an alternative default route.
+				if !hasBoshDnsInterface() {
+					Skip("bosh-dns dummy interface not present — configure_systemd_resolved not enabled on this stemcell")
+				}
+
+				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
+					"resolvectl status bosh-dns 2>/dev/null | grep Protocols"}...)
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session, 10*time.Second).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say(`-DefaultRoute`))
+			})
+
+			It("resolves external names via the OS resolver when disable_recursors is true", func() {
+				// Verify that external DNS works end-to-end via systemd-resolved's
+				// upstream (IaaS DHCP DNS), not through bosh-dns. Regression test for
+				// the warden noble DNS issue where bosh-dns incorrectly held +DefaultRoute
+				// and intercepted all external queries, returning REFUSED.
+				if !hasBoshDnsInterface() {
+					Skip("bosh-dns dummy interface not present — configure_systemd_resolved not enabled on this stemcell")
+				}
+
+				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
+					"nslookup google.com 2>&1"}...)
+				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+
+				Eventually(session, 15*time.Second).Should(gexec.Exit(0))
+				Expect(session.Out).To(gbytes.Say(`Non-authoritative answer`))
+			})
 		})
 
 		Context("external processes changing /etc/resolv.conf", func() {

--- a/src/bosh-dns/acceptance_tests/linux/linux_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/linux_test.go
@@ -167,17 +167,33 @@ var _ = Describe("Alias address binding", func() {
 				// upstream (IaaS DHCP DNS), not through bosh-dns. Regression test for
 				// the warden noble DNS issue where bosh-dns incorrectly held +DefaultRoute
 				// and intercepted all external queries, returning REFUSED.
+				//
+				// The regression only manifests when disable_recursors=true — if it is
+				// false, bosh-dns forwards external queries anyway and the test would pass
+				// even with a broken +DefaultRoute. Guard on the rendered config first.
 				if !hasBoshDnsInterface() {
 					Skip("bosh-dns dummy interface not present — configure_systemd_resolved not enabled on this stemcell")
 				}
 
+				// Read disable_recursors from the rendered config.json on the VM.
 				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
-					"nslookup google.com 2>&1"}...)
+					`python3 -c "import json; c=json.load(open('/var/vcap/jobs/bosh-dns/config/config.json')); print(c.get('disable_recursors', False))" 2>/dev/null`}...)
 				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
+				Expect(err).NotTo(HaveOccurred())
+				Eventually(session, 10*time.Second).Should(gexec.Exit(0))
+				if !strings.Contains(string(session.Out.Contents()), "True") {
+					Skip("disable_recursors is not true on this deployment — test only validates warden regression when disable_recursors=true")
+				}
+
+				// Use dig for stable output — check status: NOERROR rather than
+				// nslookup's locale-sensitive "Non-authoritative answer" string.
+				cmd = exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
+					"dig +time=5 google.com 2>&1"}...)
+				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
 				Expect(err).NotTo(HaveOccurred())
 
 				Eventually(session, 15*time.Second).Should(gexec.Exit(0))
-				Expect(session.Out).To(gbytes.Say(`Non-authoritative answer`))
+				Expect(session.Out).To(gbytes.Say(`status: NOERROR`))
 			})
 		})
 


### PR DESCRIPTION
## Problem

On ubuntu-noble, `configure_systemd_resolved=true` causes bosh-dns to create a dummy network interface (`bosh-dns`) and register it with systemd-resolved. Without an explicit `default-route=no` setting, systemd-resolved marks that interface as `+DefaultRoute` - routing **all** unmatched DNS queries (including external ones) through it.

On normal noble VMs this is harmless: the physical NIC also holds `+DefaultRoute` from DHCP, so systemd-resolved uses it for external queries. On **warden/bosh-lite containers** there is no physical NIC with DHCP DNS. The bosh-dns interface becomes the only default route for all queries.
Since `disable_recursors=true` is set for noble in `bosh-deployment/runtime-configs/dns.yml`, bosh-dns returns `REFUSED` for every external query.

## Root Cause

`bosh_dns_ctl.erb` calls `resolvectl dns bosh-dns 169.254.0.2` but never calls `resolvectl default-route bosh-dns no`. The systemd-resolved default for a link with a DNS server and no route-only domain other than `~.` is `DefaultRoute=true`.

## Fix

One line added to `create_network_interface()` in `bosh_dns_ctl.erb`:

```bash
resolvectl dns bosh-dns <%= p('address') %>
resolvectl default-route bosh-dns no    # ← new
```

This pins the interface to handle only its registered `.bosh` domains, never becoming a catch-all, regardless of whether other interfaces are present.

## Test Evidence

Tested on GCP with bosh-lite director (warden CPI), ubuntu-noble/1.396, bosh-dns 1.39.23.

**Before fix** - bosh-dns interface is `+DefaultRoute`, external DNS refused:

```
Link 17 (bosh-dns)
    Protocols: +DefaultRoute
    DNS Servers: 169.254.0.2
    DNS Domain: bosh

$ dig +time=5 @169.254.0.2 google.com
;; ->>HEADER<<- opcode: QUERY, status: REFUSED, id: 52080
;; flags: qr rd; QUERY: 1, ANSWER: 0, AUTHORITY: 0, ADDITIONAL: 0
;; WARNING: recursion requested but not available
```

**After `resolvectl default-route bosh-dns no`** - interface is `-DefaultRoute`, systemd-resolved
uses GCP DNS for external queries:

```
Link 17 (bosh-dns)
    Protocols: -DefaultRoute
    DNS Servers: 169.254.0.2
    DNS Domain: bosh

$ dig +time=5 @127.0.0.53 google.com
;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 26492
;; flags: qr rd ra; QUERY: 1, ANSWER: 6, AUTHORITY: 0, ADDITIONAL: 1

$ nslookup google.com
Server:    127.0.0.53
Address:   127.0.0.53#53
Name:      google.com
Address:   142.251.14.138
```

Internal `.bosh` resolution unaffected:

```
$ dig +short @169.254.0.2 q-s0.target.*.dns-canary.bosh
10.244.0.3
```

## Scope

- Only affects noble stemcells (`configure_systemd_resolved=true`)
- No impact on jammy - it uses `create_network_alias` on loopback, never `create_network_interface`
- No changes to `disable_recursors` or any runtime config required
- Does **not** affect the `disable_recursors=false` path: bosh-dns still forwards external queries to its configured recursors when queried directly. The `-DefaultRoute` flag only prevents the OS resolver (`127.0.0.53`) from routing queries to bosh-dns when it has no recursors to forward them to (`disable_recursors=true`)

Closes https://github.com/cloudfoundry/bosh-linux-stemcell-builder/issues/584
