### PR TITLE
ci: fix acceptence tests on jammy

### DIFF
--- a/src/bosh-dns/acceptance_tests/http_json_test.go
+++ b/src/bosh-dns/acceptance_tests/http_json_test.go
@@ -1,8 +1,6 @@
 package acceptance
 
 import (
-	"fmt"
-
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -17,32 +15,7 @@ var _ = Describe("HTTP JSON Server integration", func() {
 
 	Describe("DNS endpoint", func() {
 		BeforeEach(func() {
-			manifestPath := assetPath(testManifestName())
-			enableHTTPJSONEndpointsPath := assetPath(enableHTTPJSONEndpointsOpsFile())
-			enableConfiguresHandler := assetPath("ops/manifest/enable-configures-handler-job.yml")
-			configureRecursorPath := assetPath(configureRecursorOpsFile())
-
-			updateCloudConfigWithDefaultCloudConfig()
-
-			testHTTPDNSServerAddress := fmt.Sprintf(
-				"http://%s:8081",
-				testHTTPDNSServerIPAddress(),
-			)
-			helpers.Bosh(
-				"deploy",
-				"-o", configureRecursorPath,
-				"-o", enableHTTPJSONEndpointsPath,
-				"-o", enableConfiguresHandler,
-				"-v", fmt.Sprintf("name=%s", boshDeployment),
-				"-v", fmt.Sprintf("base_stemcell=%s", baseStemcell),
-				"-v", fmt.Sprintf("http_json_server_address=%s", testHTTPDNSServerAddress),
-				"-v", fmt.Sprintf("recursor_a=%s", RecursorIPAddresses[0]),
-				"-v", fmt.Sprintf("recursor_b=%s", RecursorIPAddresses[1]),
-				"--vars-store", "creds.yml",
-				manifestPath,
-			)
-
-			allDeployedInstances = helpers.BoshInstances("bosh-dns")
+			ensureHTTPJSONEndpointDeployed()
 			firstInstance = allDeployedInstances[0]
 		})
 

--- a/src/bosh-dns/acceptance_tests/support_test.go
+++ b/src/bosh-dns/acceptance_tests/support_test.go
@@ -67,6 +67,38 @@ func testHTTPDNSServerIPAddress() string {
 	return helpers.BoshInstances("test-http-dns-server")[0].IP
 }
 
+func ensureHTTPJSONEndpointDeployed() {
+	manifestPath := assetPath(testManifestName())
+	enableHTTPJSONEndpointsPath := assetPath(enableHTTPJSONEndpointsOpsFile())
+	enableConfiguresHandler := assetPath("ops/manifest/enable-configures-handler-job.yml")
+	configureRecursorPath := assetPath(configureRecursorOpsFile())
+
+	updateCloudConfigWithDefaultCloudConfig()
+
+	testHTTPDNSServerAddress := fmt.Sprintf(
+		"http://%s:8081",
+		testHTTPDNSServerIPAddress(),
+	)
+	args := []string{
+		"deploy",
+		"-o", configureRecursorPath,
+		"-o", enableHTTPJSONEndpointsPath,
+		"-o", enableConfiguresHandler,
+		"-v", fmt.Sprintf("name=%s", boshDeployment),
+		"-v", fmt.Sprintf("base_stemcell=%s", baseStemcell),
+		"-v", fmt.Sprintf("http_json_server_address=%s", testHTTPDNSServerAddress),
+		"-v", fmt.Sprintf("recursor_a=%s", RecursorIPAddresses[0]),
+		"-v", fmt.Sprintf("recursor_b=%s", RecursorIPAddresses[1]),
+		"--vars-store", "creds.yml",
+	}
+	if ops := stemcellDNSOpsFile(); ops != "" {
+		args = append(args, "-o", assetPath(ops))
+	}
+	args = append(args, manifestPath)
+	helpers.Bosh(args...)
+	allDeployedInstances = helpers.BoshInstances("bosh-dns")
+}
+
 func ensureRecursorIsDefinedByBoshAgent() {
 	manifestPath := assetPath(testManifestName())
 	disableOverridePath := assetPath(noRecursorsOpsFile())

--- a/src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml
+++ b/src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml
@@ -1,6 +1,6 @@
 # TODO: remove when Jammy goes EOL
 - type: replace
-  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/address
+  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/address?
   value: 0.0.0.0
 
 - type: replace


### PR DESCRIPTION
This was broken by the changes to make systemd the default. Applying the corrected Jammy ops file in more places.

Moved one bosh deploy into the support_test.go to match the others.