### PR TITLE
tests: integration tests go over ssh now

### DIFF
--- a/src/bosh-dns/acceptance_tests/helpers/bosh.go
+++ b/src/bosh-dns/acceptance_tests/helpers/bosh.go
@@ -47,6 +47,10 @@ type InstanceInfo struct {
 	ProcessState  string
 }
 
+func (i InstanceInfo) Slug() string {
+	return fmt.Sprintf("%s/%s", i.InstanceGroup, i.InstanceID)
+}
+
 func BoshInstances(deploymentName string) []InstanceInfo {
 	output := Bosh("instances", "-d", deploymentName, "--details", "--json")
 

--- a/src/bosh-dns/acceptance_tests/helpers/dns.go
+++ b/src/bosh-dns/acceptance_tests/helpers/dns.go
@@ -3,6 +3,9 @@ package helpers
 import (
 	"fmt"
 	"net"
+	"os/exec"
+	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -18,6 +21,99 @@ type DigOpts struct {
 	Timeout        time.Duration
 	Type           uint16
 	Id             uint16
+}
+
+// RemoteDig resolves domain from within the given BOSH instance using the VM's
+// system resolver. This exercises the full production DNS routing:
+//   - Jammy: /etc/resolv.conf → 169.254.0.2 (bosh-dns loopback alias)
+//   - Noble and beyond: systemd-resolved stub → routes BOSH domains to bosh-dns at 169.254.0.2
+func RemoteDig(instanceSlug, domain string) *dns.Msg {
+	return digSSH(instanceSlug, domain, fmt.Sprintf("dig +notcp %s", domain))
+}
+
+func digSSH(instanceSlug, domain, digCmd string) *dns.Msg {
+	Expect(safeDomainRe.MatchString(domain)).To(BeTrue(),
+		"domain %q contains characters unsafe for shell interpolation", domain)
+	//nolint:gosec
+	cmd := exec.Command(boshBinaryPath, "-n", "ssh", instanceSlug, "-c", digCmd)
+	out, err := cmd.Output()
+	Expect(err).NotTo(HaveOccurred(),
+		"bosh ssh dig failed for instance %s domain %s", instanceSlug, domain)
+	msg := parseDigOutput(string(out))
+	Expect(msg.Rcode).To(Equal(dns.RcodeSuccess),
+		"dig returned non-success rcode for domain %s", domain)
+	return msg
+}
+
+var (
+	digFlagsRe   = regexp.MustCompile(`flags:\s+([\w\s]+);`)
+	digAnswerRe  = regexp.MustCompile(`\b(\d+)\s+IN\s+A\s+((?:\d{1,3}\.){3}\d{1,3})`)
+	digStatusRe  = regexp.MustCompile(`status:\s+(\w+)`)
+	safeDomainRe = regexp.MustCompile(`^[a-zA-Z0-9*._-]+$`)
+)
+
+var rcodeMap = map[string]int{
+	"NOERROR":  dns.RcodeSuccess,
+	"FORMERR":  dns.RcodeFormatError,
+	"SERVFAIL": dns.RcodeServerFailure,
+	"NXDOMAIN": dns.RcodeNameError,
+	"NOTIMP":   dns.RcodeNotImplemented,
+	"REFUSED":  dns.RcodeRefused,
+}
+
+// parseDigOutput converts dig text output (including the "instance: stdout | ..."
+// prefix that bosh ssh adds) into a *dns.Msg suitable for use with gomegadns matchers.
+func parseDigOutput(output string) *dns.Msg {
+	msg := &dns.Msg{}
+
+	if m := digStatusRe.FindStringSubmatch(output); len(m) > 1 {
+		if rcode, ok := rcodeMap[m[1]]; ok {
+			msg.Rcode = rcode
+		}
+	}
+
+	if m := digFlagsRe.FindStringSubmatch(output); len(m) > 1 {
+		for _, f := range strings.Fields(m[1]) {
+			switch f {
+			case "qr":
+				msg.Response = true
+			case "aa":
+				msg.Authoritative = true
+			case "tc":
+				msg.Truncated = true
+			case "rd":
+				msg.RecursionDesired = true
+			case "ra":
+				msg.RecursionAvailable = true
+			case "ad":
+				msg.AuthenticatedData = true
+			case "cd":
+				msg.CheckingDisabled = true
+			}
+		}
+	}
+
+	for _, m := range digAnswerRe.FindAllStringSubmatch(output, -1) {
+		ttl, err := strconv.ParseUint(m[1], 10, 32)
+		if err != nil {
+			continue
+		}
+		ip := net.ParseIP(m[2])
+		if ip == nil {
+			continue
+		}
+		msg.Answer = append(msg.Answer, &dns.A{
+			Hdr: dns.RR_Header{
+				Name:   "unknown.",
+				Rrtype: dns.TypeA,
+				Class:  dns.ClassINET,
+				Ttl:    uint32(ttl),
+			},
+			A: ip,
+		})
+	}
+
+	return msg
 }
 
 func Dig(domain, server string) *dns.Msg {

--- a/src/bosh-dns/acceptance_tests/http_json_test.go
+++ b/src/bosh-dns/acceptance_tests/http_json_test.go
@@ -20,7 +20,7 @@ var _ = Describe("HTTP JSON Server integration", func() {
 		})
 
 		It("answers queries with the response from the http server", func() {
-			dnsResponse := helpers.Dig("app-id.internal.local.", firstInstance.IP)
+			dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "app-id.internal.local.")
 			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": "192.168.0.1", "ttl": 0}),
@@ -28,7 +28,7 @@ var _ = Describe("HTTP JSON Server integration", func() {
 		})
 
 		It("configures Bosh DNS handlers by producing a dns handlers json file", func() {
-			dnsResponse := helpers.Dig("handler.internal.local.", firstInstance.IP)
+			dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "handler.internal.local.")
 			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": "10.168.0.1", "ttl": 0}),

--- a/src/bosh-dns/acceptance_tests/recursors_test.go
+++ b/src/bosh-dns/acceptance_tests/recursors_test.go
@@ -17,8 +17,15 @@ var _ = Describe("recursor", func() {
 	// is cannot be moved as it modifies /etc/resolv.conf. We need to figure out
 	// how to make this change safely in integration_tests/*.
 	// [#165801868]
+	//
+	// TODO: remove when Jammy goes EOL. On Noble, bosh-dns is only a handler for
+	// BOSH-specific domains; systemd-resolved handles external queries directly so
+	// bosh-dns never does recursion in production.
 	Context("when the recursors must be read from the system resolver list", func() {
 		BeforeEach(func() {
+			if !helpers.OverrideNameserverFor(baseStemcell) {
+				Skip("bosh-dns is not the system resolver, no need to test recursion")
+			}
 			ensureRecursorIsDefinedByBoshAgent()
 			firstBoshDNS = allDeployedInstances[0]
 		})
@@ -29,7 +36,7 @@ var _ = Describe("recursor", func() {
 		})
 
 		It("forwards queries to the configured recursors on port 53", func() {
-			dnsResponse := helpers.Dig("example.com.", firstBoshDNS.IP)
+			dnsResponse := helpers.RemoteDig(firstBoshDNS.Slug(), "example.com.")
 			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": "10.10.10.10", "ttl": 5}),

--- a/src/bosh-dns/acceptance_tests/release_smoke_test.go
+++ b/src/bosh-dns/acceptance_tests/release_smoke_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/miekg/dns"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 
@@ -25,7 +24,7 @@ var _ = Describe("Integration", func() {
 
 		It("resolves alias globs", func() {
 			for _, alias := range []string{"asterisk.alias.", "another.asterisk.alias.", "yetanother.asterisk.alias."} {
-				dnsResponse := helpers.Dig(alias, firstInstance.IP)
+				dnsResponse := helpers.RemoteDig(firstInstance.Slug(), alias)
 				Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 				Expect(dnsResponse.Answer).To(ConsistOf(
 					gomegadns.MatchResponse(gomegadns.Response{"ip": allDeployedInstances[0].IP, "ttl": 0}),
@@ -35,7 +34,7 @@ var _ = Describe("Integration", func() {
 		})
 
 		It("resolves aliases from links", func() {
-			dnsResponse := helpers.Dig("dns-acceptance-alias.bosh.", firstInstance.IP)
+			dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "dns-acceptance-alias.bosh.")
 
 			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
@@ -43,7 +42,7 @@ var _ = Describe("Integration", func() {
 				gomegadns.MatchResponse(gomegadns.Response{"ip": allDeployedInstances[1].IP, "ttl": 0}),
 			))
 
-			dnsResponse = helpers.Dig(fmt.Sprintf("%s.placeholder-alias.bosh.", allDeployedInstances[0].InstanceID), firstInstance.IP)
+			dnsResponse = helpers.RemoteDig(firstInstance.Slug(), fmt.Sprintf("%s.placeholder-alias.bosh.", allDeployedInstances[0].InstanceID))
 
 			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
@@ -68,10 +67,11 @@ var _ = Describe("Integration", func() {
 
 		AfterEach(func() {
 			helpers.Bosh("start")
-			Eventually(func() []dns.RR {
-				dnsResponse := helpers.Dig("q-s0.bosh-dns.default.bosh-dns.bosh.", firstInstance.IP)
-				return dnsResponse.Answer
-			}, 60*time.Second, 1*time.Second).Should(HaveLen(len(allDeployedInstances)))
+
+			Eventually(func() int {
+				dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "q-s0.bosh-dns.default.bosh-dns.bosh.")
+				return len(dnsResponse.Answer)
+			}, 3*time.Minute, 5*time.Second).Should(Equal(len(allDeployedInstances)))
 		})
 
 		It("returns a healthy response when the instance is running", func() {

--- a/src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml
+++ b/src/bosh-dns/test_yml_assets/ops/manifest/override-nameserver-dns-settings.yml
@@ -1,9 +1,5 @@
 # TODO: remove when Jammy goes EOL
 - type: replace
-  path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/address?
-  value: 0.0.0.0
-
-- type: replace
   path: /instance_groups/name=bosh-dns/jobs/name=bosh-dns/properties/configure_systemd_resolved
   value: false
 


### PR DESCRIPTION
Integration tests used to configure bosh dns to listen on 0.0.0.0 which was not represenative of production and didn't test the systemd integration. Now we do all resolutions from inside the VM, testing the systemd integration when present.