### PR TITLE
integration tests no longer expect bosh dns responses to be authoritative

### DIFF
--- a/src/bosh-dns/acceptance_tests/http_json_test.go
+++ b/src/bosh-dns/acceptance_tests/http_json_test.go
@@ -21,7 +21,7 @@ var _ = Describe("HTTP JSON Server integration", func() {
 
 		It("answers queries with the response from the http server", func() {
 			dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "app-id.internal.local.")
-			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
+			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": "192.168.0.1", "ttl": 0}),
 			))
@@ -29,7 +29,7 @@ var _ = Describe("HTTP JSON Server integration", func() {
 
 		It("configures Bosh DNS handlers by producing a dns handlers json file", func() {
 			dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "handler.internal.local.")
-			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
+			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": "10.168.0.1", "ttl": 0}),
 			))

--- a/src/bosh-dns/acceptance_tests/recursors_test.go
+++ b/src/bosh-dns/acceptance_tests/recursors_test.go
@@ -37,6 +37,10 @@ var _ = Describe("recursor", func() {
 
 		It("forwards queries to the configured recursors on port 53", func() {
 			dnsResponse := helpers.RemoteDig(firstBoshDNS.Slug(), "example.com.")
+
+			// Per RFC 2181 §5.4.1, the AA bit should only be set when the responding server is
+			// itself authoritative for the zone — a forwarder shouldn't propagate it. bosh-dns
+			// passing through aa from an upstream is technically non-conformant.
 			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": "10.10.10.10", "ttl": 5}),

--- a/src/bosh-dns/acceptance_tests/release_smoke_test.go
+++ b/src/bosh-dns/acceptance_tests/release_smoke_test.go
@@ -25,7 +25,7 @@ var _ = Describe("Integration", func() {
 		It("resolves alias globs", func() {
 			for _, alias := range []string{"asterisk.alias.", "another.asterisk.alias.", "yetanother.asterisk.alias."} {
 				dnsResponse := helpers.RemoteDig(firstInstance.Slug(), alias)
-				Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
+				Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "rd", "ra"))
 				Expect(dnsResponse.Answer).To(ConsistOf(
 					gomegadns.MatchResponse(gomegadns.Response{"ip": allDeployedInstances[0].IP, "ttl": 0}),
 					gomegadns.MatchResponse(gomegadns.Response{"ip": allDeployedInstances[1].IP, "ttl": 0}),
@@ -36,7 +36,7 @@ var _ = Describe("Integration", func() {
 		It("resolves aliases from links", func() {
 			dnsResponse := helpers.RemoteDig(firstInstance.Slug(), "dns-acceptance-alias.bosh.")
 
-			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "aa", "rd", "ra"))
+			Expect(dnsResponse).To(gomegadns.HaveFlags("qr", "rd", "ra"))
 			Expect(dnsResponse.Answer).To(ConsistOf(
 				gomegadns.MatchResponse(gomegadns.Response{"ip": allDeployedInstances[0].IP, "ttl": 0}),
 				gomegadns.MatchResponse(gomegadns.Response{"ip": allDeployedInstances[1].IP, "ttl": 0}),


### PR DESCRIPTION
When integrating with systemd-resolved it correctly strips the authoritative bit from the DNS responses coming from bosh dns. Updating tests to expect this.

Also added a comment to a test which shows that bosh-dns does not strip the authoritiative bit when recursing. It's not RFC compliant, but likely has no effect and will be moot once Jammy goes away.