### PR TITLE
fix: have_flags matcher now ignores extra flags

### DIFF
--- a/src/bosh-dns/gomegadns/have_flags.go
+++ b/src/bosh-dns/gomegadns/have_flags.go
@@ -24,9 +24,7 @@ func (matcher *haveFlagsMatcher) Match(actual interface{}) (success bool, err er
 	if !ok {
 		return false, fmt.Errorf("HaveFlags matcher expects a *dns.Msg")
 	}
-	actualFlags := flags(msg)
-
-	return gomega.ConsistOf(matcher.expected).Match(actualFlags)
+	return gomega.ContainElements(matcher.expected).Match(flags(msg))
 }
 
 func (matcher *haveFlagsMatcher) FailureMessage(actual interface{}) (message string) {


### PR DESCRIPTION
Jammy has the 'aa' flag set, Noble+ does not, this change makes the tests work everywhere