### PR TITLE
fix wait and is-system-resolver scripts in systemd mode

### DIFF
--- a/jobs/bosh-dns/templates/is-system-resolver.erb
+++ b/jobs/bosh-dns/templates/is-system-resolver.erb
@@ -1,2 +1,13 @@
 #!/bin/bash
-exit <%= p('override_nameserver') ? 0 : 1 %>
+# Returns 0 (true) if bosh-dns is responsible for resolving BOSH-specific DNS
+# queries via the system resolver, so callers can decide whether to wait for
+# bosh-dns to be ready before querying DNS in pre-start scripts.
+#
+# On Jammy and earlier, bosh-dns owns /etc/resolv.conf (override_nameserver).
+#
+# On Noble and later, systemd-resolved is the system resolver, but bosh-dns
+# configures it to delegate BOSH-specific domains (*.bosh, etc.) to bosh-dns
+# via a virtual network interface (configure_systemd_resolved). BOSH DNS names
+# are therefore unavailable until bosh-dns has started and systemd-resolved has
+# been updated, so callers still need to wait.
+exit <%= (p('override_nameserver') || p('configure_systemd_resolved')) ? 0 : 1 %>

--- a/jobs/bosh-dns/templates/wait.erb
+++ b/jobs/bosh-dns/templates/wait.erb
@@ -3,7 +3,7 @@
 # check bosh-dns listen address
 /var/vcap/packages/bosh-dns/bin/bosh-dns-wait --address <%= p('address') %> --port <%= p('port') %> --checkDomain <%= p('upcheck_domains').first %> --timeout 5m --logFormat <%= p('logging.format.timestamp') %>
 
-<% if p('override_nameserver') %>
-# check default nameserver
+<% if p('override_nameserver') || p('configure_systemd_resolved') %>
+# check default nameserver (system resolver must also resolve the upcheck domain)
 /var/vcap/packages/bosh-dns/bin/bosh-dns-wait --checkDomain <%= p('upcheck_domains').first %> --timeout 5m --logFormat <%= p('logging.format.timestamp') %>
 <% end %>

--- a/spec/jobs/bosh-dns_spec.rb
+++ b/spec/jobs/bosh-dns_spec.rb
@@ -6,6 +6,62 @@ describe 'bosh-dns' do
 
   it_behaves_like 'common config.json'
 
+  describe 'bin/is-system-resolver' do
+    let(:template) { job.template('bin/is-system-resolver') }
+
+    context 'on Jammy (override_nameserver: true)' do
+      let(:rendered) { template.render({'override_nameserver' => true, 'configure_systemd_resolved' => false}) }
+
+      it 'exits 0 so callers know to wait for bosh-dns' do
+        expect(rendered).to include('exit 0')
+      end
+    end
+
+    context 'on Noble (configure_systemd_resolved: true, override_nameserver: false)' do
+      let(:rendered) { template.render({'override_nameserver' => false, 'configure_systemd_resolved' => true}) }
+
+      it 'exits 0 so callers know to wait for bosh-dns to integrate with systemd-resolved' do
+        expect(rendered).to include('exit 0')
+      end
+    end
+
+    context 'when bosh-dns is installed but not acting as any kind of system resolver' do
+      let(:rendered) { template.render({'override_nameserver' => false, 'configure_systemd_resolved' => false}) }
+
+      it 'exits 1 so callers skip the wait' do
+        expect(rendered).to include('exit 1')
+      end
+    end
+  end
+
+  describe 'bin/wait' do
+    let(:template) { job.template('bin/wait') }
+
+    context 'on Jammy (override_nameserver: true)' do
+      let(:rendered) { template.render({'override_nameserver' => true, 'configure_systemd_resolved' => false}) }
+
+      it 'checks bosh-dns directly and also via the system resolver' do
+        expect(rendered.scan('bosh-dns-wait').length).to eq(2)
+      end
+    end
+
+    context 'on Noble (configure_systemd_resolved: true, override_nameserver: false)' do
+      let(:rendered) { template.render({'override_nameserver' => false, 'configure_systemd_resolved' => true}) }
+
+      it 'checks bosh-dns directly and also via the system resolver' do
+        expect(rendered.scan('bosh-dns-wait').length).to eq(2)
+      end
+    end
+
+    context 'when bosh-dns is not the system resolver' do
+      let(:rendered) { template.render({'override_nameserver' => false, 'configure_systemd_resolved' => false}) }
+
+      it 'only checks bosh-dns directly' do
+        expect(rendered.scan('bosh-dns-wait').length).to eq(1)
+      end
+    end
+  end
+
   describe 'bin/bosh_dns_ctl' do
     let(:template) { job.template('bin/bosh_dns_ctl') }
     let(:rendered) { template.render({}) }

--- a/src/bosh-dns/dns/systemdresolvedupdater/main.go
+++ b/src/bosh-dns/dns/systemdresolvedupdater/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"strings"
 	"time"
 
 	"bosh-dns/dns/config"
@@ -68,10 +69,22 @@ func main() {
 		var domains []string
 		domains = append(domains, handlersConfiguration.HandlerDomains()...)
 		domains = append(domains, recordSet.Domains()...)
+		domains = append(domains, parentDomains(boshDnsConfig.UpcheckDomains)...)
+
 		err = systemdResolvedManager.UpdateDomains(domains)
 		if err != nil {
 			log.Fatal(err)
 		}
 	}
 	close(shutdown)
+}
+
+func parentDomains(fqdns []string) []string {
+	var parents []string
+	for _, fqdn := range fqdns {
+		if dotIdx := strings.Index(fqdn, "."); dotIdx >= 0 && dotIdx+1 < len(fqdn) {
+			parents = append(parents, fqdn[dotIdx+1:])
+		}
+	}
+	return parents
 }

--- a/src/bosh-dns/dns/systemdresolvedupdater/main_test.go
+++ b/src/bosh-dns/dns/systemdresolvedupdater/main_test.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestSystemdResolvedUpdater(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "SystemdResolvedUpdater Suite")
+}
+
+var _ = Describe("parentDomains", func() {
+	It("extracts the parent domain (drops the leftmost label) from each upcheck domain", func() {
+		Expect(parentDomains([]string{"upcheck.bosh-dns.", "instance.health.bosh."})).To(ConsistOf("bosh-dns.", "health.bosh."))
+	})
+
+	It("handles multiple upcheck domains", func() {
+		Expect(parentDomains([]string{"upcheck.bosh-dns.", "health.bosh."})).To(ConsistOf("bosh-dns.", "bosh."))
+	})
+
+	It("ignores domains with no dot or a trailing dot only", func() {
+		Expect(parentDomains([]string{"bosh-dns.", "bosh-dns"})).To(BeEmpty())
+	})
+
+	It("returns empty when given no domains", func() {
+		Expect(parentDomains([]string{})).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
These scripts are used by a bunch of releases to know that bosh-dns is working before starting.

The bosh-dns domain was never being registered with systemd, so upcheck.bosh-dns did not work. Releases were only working because they only run wait if is-system-resolver is true.

While bosh dns isn't technically the system resolver on Noble, the real goal of calling is system resolver is to know if bosh-dns is enabled and can be reached through the system resolver, which it can, so making this script return true in systemd mode makes the most sense.