### PR TITLE
Revert PR #156

### DIFF
--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -55,11 +55,10 @@ function create_network_interface() {
   then
     ip link add bosh-dns type dummy
     ip addr add <%= p('address') %>/32 dev bosh-dns
+    ip link set bosh-dns up
+    resolvectl dns bosh-dns <%= p('address') %>
+    resolvectl log-level <%= {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'NONE' => 'emerg'}[p('log_level')] %>
   fi
-  ip link set bosh-dns up
-  resolvectl dns bosh-dns <%= p('address') %>
-  resolvectl default-route bosh-dns no
-  resolvectl log-level <%= {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'NONE' => 'emerg'}[p('log_level')] %>
 }
 
 function remove_network_interface() {

--- a/src/bosh-dns/acceptance_tests/linux/linux_test.go
+++ b/src/bosh-dns/acceptance_tests/linux/linux_test.go
@@ -7,7 +7,6 @@ import (
 	"os/exec"
 	"regexp"
 	"strconv"
-	"strings"
 	"time"
 
 	"bosh-dns/acceptance_tests/helpers"
@@ -131,72 +130,6 @@ var _ = Describe("Alias address binding", func() {
 			Eventually(session, 10*time.Second).Should(gexec.Exit(0))
 			output := string(session.Out.Contents())
 			Expect(output).To(ContainSubstring(";; flags: qr aa rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0"))
-		})
-
-		Context("when configure_systemd_resolved is enabled (noble stemcell)", func() {
-			// The bosh-dns dummy interface is only created when configure_systemd_resolved=true,
-			// which is set exclusively for ubuntu-noble in the bosh-dns-systemd runtime config addon.
-			// On jammy and earlier, bosh-dns binds to a loopback alias instead — no bosh-dns link exists.
-			hasBoshDnsInterface := func() bool {
-				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
-					"ip link show bosh-dns > /dev/null 2>&1 && echo yes || echo no"}...)
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(session, 10*time.Second).Should(gexec.Exit(0))
-				return strings.Contains(string(session.Out.Contents()), "yes")
-			}
-
-			It("does not set the bosh-dns interface as the default DNS route", func() {
-				// bosh-dns must never hold +DefaultRoute on the bosh-dns dummy interface.
-				// If it does, all external DNS queries are routed to bosh-dns instead of
-				// the IaaS-provided upstream - causing REFUSED on warden containers where
-				// no physical NIC has DHCP DNS to serve as an alternative default route.
-				if !hasBoshDnsInterface() {
-					Skip("bosh-dns dummy interface not present — configure_systemd_resolved not enabled on this stemcell")
-				}
-
-				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
-					"resolvectl status bosh-dns 2>/dev/null | grep Protocols"}...)
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(session, 10*time.Second).Should(gexec.Exit(0))
-				Expect(session.Out).To(gbytes.Say(`-DefaultRoute`))
-			})
-
-			It("resolves external names via the OS resolver when disable_recursors is true", func() {
-				// Verify that external DNS works end-to-end via systemd-resolved's
-				// upstream (IaaS DHCP DNS), not through bosh-dns. Regression test for
-				// the warden noble DNS issue where bosh-dns incorrectly held +DefaultRoute
-				// and intercepted all external queries, returning REFUSED.
-				//
-				// The regression only manifests when disable_recursors=true — if it is
-				// false, bosh-dns forwards external queries anyway and the test would pass
-				// even with a broken +DefaultRoute. Guard on the rendered config first.
-				if !hasBoshDnsInterface() {
-					Skip("bosh-dns dummy interface not present — configure_systemd_resolved not enabled on this stemcell")
-				}
-
-				// Read disable_recursors from the rendered config.json on the VM.
-				cmd := exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
-					`python3 -c "import json; c=json.load(open('/var/vcap/jobs/bosh-dns/config/config.json')); print(c.get('disable_recursors', False))" 2>/dev/null`}...)
-				session, err := gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-				Eventually(session, 10*time.Second).Should(gexec.Exit(0))
-				if !strings.Contains(string(session.Out.Contents()), "True") {
-					Skip("disable_recursors is not true on this deployment — test only validates warden regression when disable_recursors=true")
-				}
-
-				// Use dig for stable output — check status: NOERROR rather than
-				// nslookup's locale-sensitive "Non-authoritative answer" string.
-				cmd = exec.Command(boshBinaryPath, []string{"ssh", firstInstanceSlug, "-c",
-					"dig +time=5 google.com 2>&1"}...)
-				session, err = gexec.Start(cmd, GinkgoWriter, GinkgoWriter)
-				Expect(err).NotTo(HaveOccurred())
-
-				Eventually(session, 15*time.Second).Should(gexec.Exit(0))
-				Expect(session.Out).To(gbytes.Say(`status: NOERROR`))
-			})
 		})
 
 		Context("external processes changing /etc/resolv.conf", func() {


### PR DESCRIPTION
Upon further testing, the change in the PR does not actually address the DNS issues on Noble Warden. Reverting the changes to avoid any unexpected behaviour that might be caused by them.