### PR TITLE
ci: upload bpm release to director

### DIFF
--- a/ci/tasks/test-acceptance.sh
+++ b/ci/tasks/test-acceptance.sh
@@ -30,6 +30,9 @@ bosh upload-stemcell bosh-stemcell/*.tgz
 
 bosh upload-release "$PWD"/candidate-release/*.tgz
 
+BPM_VERSION=$(bosh int /usr/local/bosh-deployment/bosh.yml --path /releases/name=bpm/version)
+bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=${BPM_VERSION}"
+
 pushd "$PWD/bosh-dns-release"
   ./scripts/run-acceptance-tests
 popd

--- a/ci/tasks/test-stress/deploy-docker.sh
+++ b/ci/tasks/test-stress/deploy-docker.sh
@@ -29,6 +29,10 @@ main() {
     bosh upload-stemcell $stemcell_path
     bosh upload-release $bosh_dns_release_tarball
 
+    local bpm_version
+    bpm_version=$(bosh int "${bosh_deployment_repo}/bosh.yml" --path /releases/name=bpm/version)
+    bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=${bpm_version}"
+
     bosh -n deploy -d docker deployments/docker.yml \
       -l vars/docker-vars.yml \
       -v director_ip=$(echo $BOSH_ENVIRONMENT | sed 's#https://##g' | sed 's#:.*##g') \


### PR DESCRIPTION
Bosh dns now requires BPM, so it needs to be uploaded before the deploy.