### PR TITLE
make bpm use optional

### DIFF
--- a/ci/tasks/test-acceptance.sh
+++ b/ci/tasks/test-acceptance.sh
@@ -31,7 +31,14 @@ bosh upload-stemcell bosh-stemcell/*.tgz
 bosh upload-release "$PWD"/candidate-release/*.tgz
 
 BPM_VERSION=$(bosh int /usr/local/bosh-deployment/bosh.yml --path /releases/name=bpm/version)
-bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=${BPM_VERSION}"
+if [[ "${BASE_STEMCELL:-ubuntu-noble}" == "ubuntu-noble" ]]; then
+  # Use pre-compiled release for noble — no compilation needed, faster
+  bosh upload-release /usr/local/releases/bpm.tgz
+else
+  # Download source release so the director can compile BPM for non-noble stemcells
+  curl -fsSLo /tmp/bpm-src.tgz "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=${BPM_VERSION}"
+  bosh upload-release /tmp/bpm-src.tgz
+fi
 
 pushd "$PWD/bosh-dns-release"
   ./scripts/run-acceptance-tests

--- a/ci/tasks/test-stress/deploy-docker.sh
+++ b/ci/tasks/test-stress/deploy-docker.sh
@@ -29,9 +29,9 @@ main() {
     bosh upload-stemcell $stemcell_path
     bosh upload-release $bosh_dns_release_tarball
 
-    local bpm_version
-    bpm_version=$(bosh int "${bosh_deployment_repo}/bosh.yml" --path /releases/name=bpm/version)
-    bosh upload-release "https://bosh.io/d/github.com/cloudfoundry/bpm-release?v=${bpm_version}"
+    local bpm_url
+    bpm_url=$(bosh int "${bosh_deployment_repo}/bosh.yml" --path /releases/name=bpm/url)
+    bosh upload-release "${bpm_url}"
 
     bosh -n deploy -d docker deployments/docker.yml \
       -l vars/docker-vars.yml \

--- a/jobs/bosh-dns/monit
+++ b/jobs/bosh-dns/monit
@@ -1,8 +1,16 @@
+<% if p('use_bpm') %>
 check process bosh-dns
   with pidfile /var/vcap/sys/run/bpm/bosh-dns/bosh-dns.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start bosh-dns"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop bosh-dns"
   group vcap
+<% else %>
+check process bosh-dns
+  with pidfile /var/vcap/sys/run/bosh-dns/bosh-dns.pid
+  start program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_ctl start"
+  stop program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_ctl stop"
+  group vcap
+<% end %>
 <% if p('override_nameserver') %>
 check process bosh-dns-resolvconf
   with pidfile /var/vcap/sys/run/bosh-dns/bosh_dns_resolvconf.pid
@@ -11,9 +19,17 @@ check process bosh-dns-resolvconf
   group vcap
 <% end %>
 <% if p('health.enabled') %>
+<% if p('use_bpm') %>
 check process bosh-dns-healthcheck
   with pidfile /var/vcap/sys/run/bpm/bosh-dns/bosh-dns-health.pid
   start program "/var/vcap/jobs/bpm/bin/bpm start bosh-dns -p bosh-dns-health"
   stop program "/var/vcap/jobs/bpm/bin/bpm stop bosh-dns -p bosh-dns-health"
   group vcap
+<% else %>
+check process bosh-dns-healthcheck
+  with pidfile /var/vcap/sys/run/bosh-dns/bosh_dns_health.pid
+  start program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_health_ctl start"
+  stop program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_health_ctl stop"
+  group vcap
+<% end %>
 <% end %>

--- a/jobs/bosh-dns/spec
+++ b/jobs/bosh-dns/spec
@@ -4,6 +4,8 @@ name: bosh-dns
 templates:
   aliases.json.erb: dns/aliases.json
   bpm.yml.erb: config/bpm.yml
+  bosh_dns_ctl.erb: bin/bosh_dns_ctl
+  bosh_dns_health_ctl.erb: bin/bosh_dns_health_ctl
   bosh_dns_resolvconf_ctl.erb: bin/bosh_dns_resolvconf_ctl
   cli.erb: bin/cli
   config.json.erb: config/config.json
@@ -185,3 +187,10 @@ properties:
   logging.tags:
     description: "Provide logging configuration for log tags to overwrite the default logger behavior (e.g log_level property). Note that when override_nameserver is disabled and configure_systemd_resolved is enabled under Noble, bosh-dns will not receive all dns traffic so only bosh-dns queries can be logged."
     default: []
+
+  use_bpm:
+    description: >
+      When true, run this job under BPM. BPM is required on Resolute Raccoon
+      stemcells; support for running without BPM will be removed in a future
+      version.
+    default: false

--- a/jobs/bosh-dns/templates/bosh_dns_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_ctl.erb
@@ -1,0 +1,151 @@
+#!/bin/bash -exu
+
+set -o pipefail
+
+RUN_DIR=/var/vcap/sys/run/bosh-dns
+PIDFILE=$RUN_DIR/bosh-dns.pid
+LOG_DIR=/var/vcap/sys/log/bosh-dns
+JOB_DIR=/var/vcap/jobs/bosh-dns
+DNS_PACKAGE=/var/vcap/packages/bosh-dns
+SCRIPT_NAME=bosh_dns_ctl
+
+function start_logging() {
+  exec > >(prepend_datetime >> $LOG_DIR/${SCRIPT_NAME}.stdout.log)
+  exec 2> >(prepend_datetime >> $LOG_DIR/${SCRIPT_NAME}.stderr.log)
+}
+
+function prepend_datetime() {
+  LOG_FORMAT=<%= p('logging.format.timestamp') %>
+
+  if [ "$LOG_FORMAT" == "deprecated" ]; then
+    awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }'
+  else
+    perl -ne 'BEGIN { use Time::HiRes "time"; use POSIX "strftime"; STDOUT->autoflush(1) }; my $t = time; my $fsec = sprintf ".%09d", ($t-int($t))*1000000000; my $time = strftime("[%Y-%m-%dT%H:%M:%S".$fsec."Z]", localtime $t); print("$time $_")'
+  fi
+}
+
+function pid_exists() {
+  ps -p $1 &> /dev/null
+}
+
+function create_directories_and_chown_to_vcap() {
+  mkdir -p "${LOG_DIR}"
+  chown -R vcap:vcap "${LOG_DIR}"
+
+  mkdir -p "${RUN_DIR}"
+  chown -R vcap:vcap "${RUN_DIR}"
+}
+
+function create_network_alias() {
+  if ! ip addr show dev lo | grep -q <%= p('address') %>
+  then
+    ip addr add <%= p('address') %> dev lo
+  fi
+}
+
+function remove_network_alias() {
+  if ip addr show dev lo | grep -q <%= p('address') %>
+  then
+    ip addr del <%= p('address') %>/32 dev lo
+  fi
+}
+
+function create_network_interface() {
+  if ! ip addr show dev bosh-dns
+  then
+    ip link add bosh-dns type dummy
+    ip addr add <%= p('address') %>/32 dev bosh-dns
+    ip link set bosh-dns up
+    resolvectl dns bosh-dns <%= p('address') %>
+    resolvectl log-level <%= {'DEBUG' => 'debug', 'INFO' => 'info', 'WARN' => 'warning', 'ERROR' => 'err', 'NONE' => 'emerg'}[p('log_level')] %>
+  fi
+}
+
+function remove_network_interface() {
+  if ip addr show dev bosh-dns
+  then
+    ip link delete bosh-dns
+  fi
+}
+
+function start_dns() {
+  if [ -e "$PIDFILE" ]; then
+    pid=$(head -1 "${PIDFILE}")
+    if pid_exists "$pid"; then
+      return 0
+    fi
+  fi
+
+  setcap cap_net_bind_service=+ep ${DNS_PACKAGE}/bin/bosh-dns
+  ulimit -n 65536
+
+  pushd ${JOB_DIR}
+
+  setpriv --reuid=vcap --regid=vcap --clear-groups -- \
+    "${DNS_PACKAGE}/bin/bosh-dns" \
+    --config "${JOB_DIR}/config/config.json" \
+    1>> ${LOG_DIR}/bosh_dns.stdout.log \
+    2>> ${LOG_DIR}/bosh_dns.stderr.log &
+  popd
+
+  echo $! > $PIDFILE
+}
+
+function stop_dns() {
+  local pid
+
+  if [ -e $PIDFILE ]
+  then
+    pid=$(head -1 $PIDFILE)
+  else
+    exit 0
+  fi
+
+  if [ ! -z $pid ] && pid_exists $pid
+  then
+    set +e
+    kill -15 $pid
+    set -e
+  fi
+
+  if [ -e /proc/$pid ]
+  then
+    set +e
+    kill -9 $pid
+    set -e
+  fi
+
+  rm -f $PIDFILE
+}
+
+function main() {
+  create_directories_and_chown_to_vcap
+  start_logging
+
+  case ${1} in
+    start)
+      <% if p('configure_systemd_resolved') -%>
+      create_network_interface
+      "${DNS_PACKAGE}/bin/bosh-dns-systemd-resolved-updater" --config "${JOB_DIR}/config/config.json"
+      <% else -%>
+      create_network_alias
+      <% end -%>
+      start_dns
+      ;;
+
+    stop)
+      stop_dns
+      <% if p('configure_systemd_resolved') -%>
+      remove_network_interface
+      <% else -%>
+      remove_network_alias
+      <% end -%>
+      ;;
+
+    *)
+      echo "Usage: ${0} {start|stop}"
+      ;;
+  esac
+}
+
+main $@

--- a/jobs/bosh-dns/templates/bosh_dns_health_ctl.erb
+++ b/jobs/bosh-dns/templates/bosh_dns_health_ctl.erb
@@ -1,0 +1,107 @@
+#!/bin/bash -exu
+
+set -o pipefail
+
+RUN_DIR=/var/vcap/sys/run/bosh-dns
+PIDFILE=$RUN_DIR/bosh_dns_health.pid
+LOG_DIR=/var/vcap/sys/log/bosh-dns
+JOB_DIR=/var/vcap/jobs/bosh-dns
+DNS_PACKAGE=/var/vcap/packages/bosh-dns
+SCRIPT_NAME=bosh_dns_health_ctl
+LOG_FORMAT=<%= p('logging.format.timestamp') %>
+
+function start_logging() {
+  exec > >(prepend_datetime >> $LOG_DIR/${SCRIPT_NAME}.stdout.log)
+  exec 2> >(prepend_datetime >> $LOG_DIR/${SCRIPT_NAME}.stderr.log)
+}
+
+function prepend_datetime() {
+  if [ "$LOG_FORMAT" == "deprecated" ]; then
+    awk -W interactive '{ system("echo -n [$(date +\"%Y-%m-%d %H:%M:%S%z\")]"); print " " $0 }'
+  else
+    perl -ne 'BEGIN { use Time::HiRes "time"; use POSIX "strftime"; STDOUT->autoflush(1) }; my $t = time; my $fsec = sprintf ".%09d", ($t-int($t))*1000000000; my $time = strftime("[%Y-%m-%dT%H:%M:%S".$fsec."Z]", localtime $t); print("$time $_")'
+  fi
+}
+
+function pid_exists() {
+  ps -p $1 &> /dev/null
+}
+
+function create_directories_and_chown_to_vcap() {
+  mkdir -p "${LOG_DIR}"
+  chown -R vcap:vcap "${LOG_DIR}"
+
+  mkdir -p "${RUN_DIR}"
+  chown -R vcap:vcap "${RUN_DIR}"
+}
+
+function start_process() {
+  if [ -e "$PIDFILE" ]; then
+    pid=$(head -1 "${PIDFILE}")
+    if pid_exists "$pid"; then
+      return 0
+    fi
+  fi
+
+  pushd ${JOB_DIR}
+  # Allowed number of open file descriptors
+  ulimit -v unlimited
+  ulimit -n 4096
+
+  setpriv --reuid=vcap --regid=vcap --clear-groups --no-new-privs -- \
+    "${DNS_PACKAGE}/bin/bosh-dns-health" \
+    config/health_server_config.json \
+    1>> ${LOG_DIR}/bosh_dns_health.stdout.log \
+    2>> ${LOG_DIR}/bosh_dns_health.stderr.log &
+  popd
+
+  echo $! > $PIDFILE
+}
+
+function stop_process() {
+  local pid
+
+  if [ -e $PIDFILE ]
+  then
+    pid=$(head -1 $PIDFILE)
+  else
+    exit 0
+  fi
+
+  if [ ! -z $pid ] && pid_exists $pid
+  then
+    set +e
+    kill -15 $pid
+    set -e
+  fi
+
+  if [ -e /proc/$pid ]
+  then
+    set +e
+    kill -9 $pid
+    set -e
+  fi
+
+  rm -f $PIDFILE
+}
+
+function main() {
+  create_directories_and_chown_to_vcap
+  start_logging
+
+  case ${1} in
+    start)
+      start_process
+      ;;
+
+    stop)
+      stop_process
+      ;;
+
+    *)
+      echo "Usage: ${0} {start|stop}"
+      ;;
+  esac
+}
+
+main $@

--- a/jobs/bosh-dns/templates/pre-start.erb
+++ b/jobs/bosh-dns/templates/pre-start.erb
@@ -59,11 +59,17 @@ create_network_interface
 create_network_alias
 <% end -%>
 
+<% if p('use_bpm') -%>
 <% if p('health.enabled') -%>
 /var/vcap/jobs/bpm/bin/bpm start bosh-dns -p bosh-dns-health
 <% end -%>
-
 /var/vcap/jobs/bpm/bin/bpm start bosh-dns
+<% else -%>
+<% if p('health.enabled') -%>
+/var/vcap/jobs/bosh-dns/bin/bosh_dns_health_ctl start
+<% end -%>
+/var/vcap/jobs/bosh-dns/bin/bosh_dns_ctl start
+<% end -%>
 
 <% if p('override_nameserver') -%>
 /var/vcap/jobs/bosh-dns/bin/bosh_dns_resolvconf_ctl start

--- a/spec/jobs/bosh-dns_spec.rb
+++ b/spec/jobs/bosh-dns_spec.rb
@@ -1,5 +1,11 @@
 require_relative 'shared_examples'
 
+def render_monit(properties = {})
+  job_dir = File.join(File.dirname(__FILE__), '../../jobs/bosh-dns')
+  spec = YAML.safe_load(File.read(File.join(job_dir, 'spec')))
+  Bosh::Template::Test::Template.new(spec, File.join(job_dir, 'monit')).render(properties)
+end
+
 describe 'bosh-dns' do
   let(:release) { Bosh::Template::Test::ReleaseDir.new(File.join(File.dirname(__FILE__), '../..')) }
   let(:job) { release.job('bosh-dns') }
@@ -123,22 +129,49 @@ describe 'bosh-dns' do
   describe 'bin/pre-start' do
     let(:template) { job.template('bin/pre-start') }
 
-    it 'starts bosh-dns via bpm so DNS is available during other jobs pre-starts' do
-      rendered = template.render({})
-      expect(rendered).to include('/var/vcap/jobs/bpm/bin/bpm start bosh-dns')
-    end
+    context 'when use_bpm is false (default)' do
+      it 'starts bosh-dns via the ctl script so DNS is available during other jobs pre-starts' do
+        rendered = template.render({})
+        expect(rendered).to include('/var/vcap/jobs/bosh-dns/bin/bosh_dns_ctl start')
+        expect(rendered).not_to include('bpm start bosh-dns')
+      end
 
-    context 'when health.enabled is true' do
-      it 'starts the health process before bosh-dns' do
-        rendered = template.render({'health' => {'enabled' => true}})
-        expect(rendered).to match(%r{bpm start bosh-dns -p bosh-dns-health.*bpm start bosh-dns$}m)
+      context 'when health.enabled is true' do
+        it 'starts the health process via ctl before bosh-dns' do
+          rendered = template.render({'health' => {'enabled' => true}})
+          expect(rendered).to match(%r{bosh_dns_health_ctl start.*bosh_dns_ctl start}m)
+          expect(rendered).not_to include('bpm start')
+        end
+      end
+
+      context 'when health.enabled is false (default)' do
+        it 'does not start the health process' do
+          rendered = template.render({})
+          expect(rendered).not_to include('bosh-dns-health')
+          expect(rendered).not_to include('bosh_dns_health_ctl')
+        end
       end
     end
 
-    context 'when health.enabled is false (default)' do
-      it 'does not start the health process' do
-        rendered = template.render({})
-        expect(rendered).not_to include('bosh-dns-health')
+    context 'when use_bpm is true' do
+      it 'starts bosh-dns via bpm so DNS is available during other jobs pre-starts' do
+        rendered = template.render({'use_bpm' => true})
+        expect(rendered).to include('/var/vcap/jobs/bpm/bin/bpm start bosh-dns')
+        expect(rendered).not_to include('bosh_dns_ctl start')
+      end
+
+      context 'when health.enabled is true' do
+        it 'starts the health process via bpm before bosh-dns' do
+          rendered = template.render({'use_bpm' => true, 'health' => {'enabled' => true}})
+          expect(rendered).to match(%r{bpm start bosh-dns -p bosh-dns-health.*bpm start bosh-dns$}m)
+        end
+      end
+
+      context 'when health.enabled is false (default)' do
+        it 'does not start the health process' do
+          rendered = template.render({'use_bpm' => true})
+          expect(rendered).not_to include('bosh-dns-health')
+        end
       end
     end
 
@@ -157,6 +190,50 @@ describe 'bosh-dns' do
       it 'invokes the dummy interface setup and runs the systemd-resolved updater' do
         expect(rendered).to match(/^create_network_interface$/)
         expect(rendered).to include('bosh-dns-systemd-resolved-updater')
+      end
+    end
+  end
+
+  describe 'monit' do
+    context 'when use_bpm is false (default)' do
+      let(:rendered) { render_monit({}) }
+
+      it 'uses the ctl script pidfile and start/stop programs' do
+        expect(rendered).to include('with pidfile /var/vcap/sys/run/bosh-dns/bosh-dns.pid')
+        expect(rendered).to include('start program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_ctl start"')
+        expect(rendered).to include('stop program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_ctl stop"')
+        expect(rendered).not_to include('/var/vcap/jobs/bpm/bin/bpm')
+      end
+
+      context 'when health.enabled is true' do
+        let(:rendered) { render_monit({'health' => {'enabled' => true}}) }
+
+        it 'uses the health ctl script pidfile and start/stop programs' do
+          expect(rendered).to include('with pidfile /var/vcap/sys/run/bosh-dns/bosh_dns_health.pid')
+          expect(rendered).to include('start program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_health_ctl start"')
+          expect(rendered).to include('stop program "/var/vcap/jobs/bosh-dns/bin/bosh_dns_health_ctl stop"')
+        end
+      end
+    end
+
+    context 'when use_bpm is true' do
+      let(:rendered) { render_monit({'use_bpm' => true}) }
+
+      it 'uses the bpm pidfile and start/stop programs' do
+        expect(rendered).to include('with pidfile /var/vcap/sys/run/bpm/bosh-dns/bosh-dns.pid')
+        expect(rendered).to include('start program "/var/vcap/jobs/bpm/bin/bpm start bosh-dns"')
+        expect(rendered).to include('stop program "/var/vcap/jobs/bpm/bin/bpm stop bosh-dns"')
+        expect(rendered).not_to include('bosh_dns_ctl')
+      end
+
+      context 'when health.enabled is true' do
+        let(:rendered) { render_monit({'use_bpm' => true, 'health' => {'enabled' => true}}) }
+
+        it 'uses the bpm health pidfile and start/stop programs' do
+          expect(rendered).to include('with pidfile /var/vcap/sys/run/bpm/bosh-dns/bosh-dns-health.pid')
+          expect(rendered).to include('start program "/var/vcap/jobs/bpm/bin/bpm start bosh-dns -p bosh-dns-health"')
+          expect(rendered).to include('stop program "/var/vcap/jobs/bpm/bin/bpm stop bosh-dns -p bosh-dns-health"')
+        end
       end
     end
   end


### PR DESCRIPTION
When deployed as an add on requiring bpm is problematic as the version of bpm in the add on must exactly match the version in the deployment manifest. Making it optional for now, allowing for a transition period.

