### PR TITLE
Remove bpm from test-stress job

### DIFF
--- a/ci/assets/test-stress/bosh-workspace/deployments/bosh-dns.yml
+++ b/ci/assets/test-stress/bosh-workspace/deployments/bosh-dns.yml
@@ -14,8 +14,6 @@ instance_groups:
   stemcell: default
   azs: [d1, d2, d3, d4, d5, d6, d7, d8, d9, d10]
   jobs:
-  - name: bpm
-    release: bpm
   - name: bosh-dns
     release: bosh-dns
     properties:
@@ -38,8 +36,6 @@ instance_groups:
   vm_extensions: [tcp_22]
 releases:
 - name: bosh-dns
-  version: latest
-- name: bpm
   version: latest
 - name: dns-lookuper
   version: latest

--- a/ci/tasks/test-stress/deploy-docker.sh
+++ b/ci/tasks/test-stress/deploy-docker.sh
@@ -29,10 +29,6 @@ main() {
     bosh upload-stemcell $stemcell_path
     bosh upload-release $bosh_dns_release_tarball
 
-    local bpm_url
-    bpm_url=$(bosh int "${bosh_deployment_repo}/bosh.yml" --path /releases/name=bpm/url)
-    bosh upload-release "${bpm_url}"
-
     bosh -n deploy -d docker deployments/docker.yml \
       -l vars/docker-vars.yml \
       -v director_ip=$(echo $BOSH_ENVIRONMENT | sed 's#https://##g' | sed 's#:.*##g') \


### PR DESCRIPTION
In https://github.com/cloudfoundry/bosh-dns-release/pull/170 bpm was made optional.  We want to test this in the pipeline, so test-stress can use non-bpm to run bosh-dns.  In addition, the version of bpm was being pulled as a compiled noble release, which won't work for jammy.

Effectively reverts:
* https://github.com/cloudfoundry/bosh-dns-release/pull/167
* https://github.com/cloudfoundry/bosh-dns-release/pull/168